### PR TITLE
Setting intermediate size back to its original definition

### DIFF
--- a/src/bert_layers/layers.py
+++ b/src/bert_layers/layers.py
@@ -298,7 +298,7 @@ class FlexBertUnpadParallelPreNormLayer(FlexBertLayerBase):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
         self.attn_size = config.hidden_size * 3
-        self.mlp_size = config.intermediate_size
+        self.mlp_size = config.intermediate_size * 2
         # Compute QKV and FF outputs at once
         self.Wqkvff = nn.Linear(config.hidden_size, self.attn_size + self.mlp_size, bias=config.attn_qkv_bias)
         self.norm = get_norm_layer(config)
@@ -355,7 +355,7 @@ class FlexBertPaddedParallelPreNormLayer(FlexBertLayerBase):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
         self.attn_size = config.hidden_size * 3
-        self.mlp_size = config.intermediate_size
+        self.mlp_size = config.intermediate_size * 2
         # Compute QKV and FF outputs at once
         self.Wqkvff = nn.Linear(config.hidden_size, self.attn_size + self.mlp_size, bias=config.attn_qkv_bias)
         self.norm = get_norm_layer(config)

--- a/src/bert_layers/layers.py
+++ b/src/bert_layers/layers.py
@@ -342,7 +342,7 @@ class FlexBertPaddedPreNormLayer(FlexBertLayerBase):
         """Forward pass for a BERT layer, including both attention and MLP.
 
         Args:
-            hidden_states: (total_nnz, dim)
+            hidden_states: (batch, max_seqlen, dim)
             attn_mask: None or (batch, max_seqlen)
         """
         attn_out = hidden_states + self.attn(self.attn_norm(hidden_states), attn_mask)
@@ -370,7 +370,7 @@ class FlexBertPaddedParallelPreNormLayer(FlexBertLayerBase):
         """Forward pass for a BERT layer, including both attention and MLP.
 
         Args:
-            hidden_states: (total_nnz, dim)
+            hidden_states: (batch, max_seqlen, dim)
             attn_mask: None or (batch, max_seqlen)
         """
         # Compute QKV and FF outputs at once and split them
@@ -427,7 +427,7 @@ class FlexBertPaddedPostNormLayer(FlexBertLayerBase):
         """Forward pass for a BERT layer, including both attention and MLP.
 
         Args:
-            hidden_states: (total_nnz, dim)
+            hidden_states: (batch, max_seqlen, dim)
             attn_mask: None or (batch, max_seqlen)
         """
         attn_out = self.attn_norm(hidden_states + self.attn(hidden_states, attn_mask))

--- a/src/bert_layers/mlp.py
+++ b/src/bert_layers/mlp.py
@@ -107,10 +107,10 @@ class FlexBertGLU(FlexBertMLPBase):
 
     def __init__(self, config: FlexBertConfig):
         super().__init__()
-        self.Wi = nn.Linear(config.hidden_size, int(config.intermediate_size), bias=config.mlp_in_bias)
+        self.Wi = nn.Linear(config.hidden_size, int(config.intermediate_size) * 2 , bias=config.mlp_in_bias)
         self.act = get_act_fn(config)
         self.drop = nn.Dropout(config.mlp_dropout_prob) if config.mlp_dropout_prob > 0.0 else nn.Identity()
-        self.Wo = nn.Linear(config.intermediate_size // 2, config.hidden_size, bias=config.mlp_out_bias)
+        self.Wo = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_out_bias)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         input, gate = self.Wi(hidden_states).chunk(2, dim=-1)
@@ -128,7 +128,7 @@ class FlexBertParallelGLU(FlexBertMLPBase):
         super().__init__()
         self.act = get_act_fn(config)
         self.drop = nn.Dropout(config.mlp_dropout_prob) if config.mlp_dropout_prob > 0.0 else nn.Identity()
-        self.Wo = nn.Linear(config.intermediate_size // 2, config.hidden_size, bias=config.mlp_out_bias)
+        self.Wo = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_out_bias)
 
     def forward(self, intermediate_ff: torch.Tensor) -> torch.Tensor:
         input, gate = intermediate_ff.chunk(2, dim=-1)


### PR DESCRIPTION
As discussed on discord, during the refactor, the intermediate_size of the GLU was cut in half, this PR set it back to its original definition for consistency.
I also took the opportunity to fix some typos in the docstrings.