### PR TITLE
Allow resizing the model embeddings layer to fit the tokenizer

### DIFF
--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -69,7 +69,7 @@ class FlexBertConfig(TransformersBertConfig):
         rotary_emb_interleaved: bool = False,
         use_fa2: bool = True,
         use_sdpa_attn_mask: bool = False,
-        allow_embedding_resizing: bool = True,
+        allow_embedding_resizing: bool = False,
         **kwargs,
     ):
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -69,6 +69,7 @@ class FlexBertConfig(TransformersBertConfig):
         rotary_emb_interleaved: bool = False,
         use_fa2: bool = True,
         use_sdpa_attn_mask: bool = False,
+        allow_embedding_resizing: bool = True,
         **kwargs,
     ):
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
@@ -107,6 +108,7 @@ class FlexBertConfig(TransformersBertConfig):
         self.rotary_emb_interleaved = rotary_emb_interleaved
         self.use_fa2 = use_fa2
         self.use_sdpa_attn_mask = use_sdpa_attn_mask
+        self.allow_embedding_resizing = allow_embedding_resizing
 
 
 PADDING = ["unpadded", "padded"]

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -132,7 +132,7 @@ def create_flex_bert_mlm(
         MaskedAccuracy(ignore_index=-100),
     ]
 
-    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics, allow_embedding_resizing=True)
+    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics, allow_embedding_resizing=model.config.allow_embedding_resizing)
 
     # Padding for divisibility by 8
     # We have to do it again here because wrapping by HuggingFaceModel changes it
@@ -282,7 +282,7 @@ def create_flex_bert_classification(
         if num_labels == 2:
             metrics.append(BinaryF1Score())
 
-    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics, allow_embedding_resizing=True)
+    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics, allow_embedding_resizing=model.config.allow_embedding_resizing)
 
     # Padding for divisibility by 8
     # We have to do it again here because wrapping by HuggingFaceModel changes it

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -132,7 +132,7 @@ def create_flex_bert_mlm(
         MaskedAccuracy(ignore_index=-100),
     ]
 
-    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics)
+    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics, allow_embedding_resizing=True)
 
     # Padding for divisibility by 8
     # We have to do it again here because wrapping by HuggingFaceModel changes it
@@ -282,7 +282,7 @@ def create_flex_bert_classification(
         if num_labels == 2:
             metrics.append(BinaryF1Score())
 
-    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics)
+    hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics, allow_embedding_resizing=True)
 
     # Padding for divisibility by 8
     # We have to do it again here because wrapping by HuggingFaceModel changes it


### PR DESCRIPTION
Since the tokenizer has not the same number of tokens than the base model embeddings, we need to allow resizing it.

I insist, but maybe it's better we get ride of anything that is set as default by the base model and explicitly define everything in the config.