### PR TITLE
[WIP] Fixing some issues with the use of act/norm/pooling config parameters and consistency with MosaicBERT

### DIFF
--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -63,7 +63,7 @@ class FlexBertConfig(TransformersBertConfig):
         head_pred_bias: bool = False,
         head_pred_dropout: float = 0.0,
         head_pred_norm: bool = True,
-        pooling_type: str = "mean",
+        pooling_type: str = "cls",
         rotary_emb_dim: int | None = None,
         rotary_emb_base: float = 10000.0,
         rotary_emb_scale_base=None,

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -10,6 +10,7 @@ class BertConfig(TransformersBertConfig):
         alibi_starting_size: int = 512,
         normalization: str = "layernorm",
         attention_probs_dropout_prob: float = 0.0,
+        head_pred_act: str = "gelu",
         **kwargs,
     ):
         """Configuration class for MosaicBert.
@@ -28,6 +29,7 @@ class BertConfig(TransformersBertConfig):
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
         self.alibi_starting_size = alibi_starting_size
         self.normalization = normalization
+        self.head_pred_act = head_pred_act
 
 
 class FlexBertConfig(TransformersBertConfig):

--- a/src/bert_layers/layers.py
+++ b/src/bert_layers/layers.py
@@ -242,7 +242,7 @@ class BertPredictionHeadTransform(nn.Module):
         super().__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         if isinstance(config.hidden_act, str):
-            self.transform_act_fn = get_act_fn(config.hidden_act)
+            self.transform_act_fn = get_act_fn(config.head_pred_act)
         else:
             self.transform_act_fn = config.hidden_act
         self.LayerNorm = get_norm_layer(config)

--- a/src/bert_layers/mlp.py
+++ b/src/bert_layers/mlp.py
@@ -84,7 +84,7 @@ class FlexBertMLP(FlexBertMLPBase):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
         self.Wi = nn.Linear(config.hidden_size, config.intermediate_size, bias=config.mlp_in_bias)
-        self.act = get_act_fn(config)
+        self.act = get_act_fn(config.hidden_act)
         self.drop = nn.Dropout(config.mlp_dropout_prob) if config.mlp_dropout_prob > 0.0 else nn.Identity()
         self.Wo = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_out_bias)
 
@@ -108,7 +108,7 @@ class FlexBertGLU(FlexBertMLPBase):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
         self.Wi = nn.Linear(config.hidden_size, int(config.intermediate_size) * 2 , bias=config.mlp_in_bias)
-        self.act = get_act_fn(config)
+        self.act = get_act_fn(config.hidden_act)
         self.drop = nn.Dropout(config.mlp_dropout_prob) if config.mlp_dropout_prob > 0.0 else nn.Identity()
         self.Wo = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_out_bias)
 
@@ -126,7 +126,7 @@ class FlexBertParallelGLU(FlexBertMLPBase):
 
     def __init__(self, config: FlexBertConfig):
         super().__init__()
-        self.act = get_act_fn(config)
+        self.act = get_act_fn(config.hidden_act)
         self.drop = nn.Dropout(config.mlp_dropout_prob) if config.mlp_dropout_prob > 0.0 else nn.Identity()
         self.Wo = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_out_bias)
 

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -535,7 +535,7 @@ class FlexBertPredictionHead(nn.Module):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size, config.head_pred_bias)
-        self.act = get_act_fn(config) if config.head_pred_act else nn.Identity()
+        self.act = get_act_fn(config.head_pred_act) if config.head_pred_act else nn.Identity()
         self.norm = get_norm_layer(config) if config.head_pred_norm else nn.Identity()
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -546,7 +546,7 @@ class FlexBertPoolingHead(nn.Module):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size, config.head_class_bias)
-        self.act = get_act_fn(config) if config.head_class_act else nn.Identity()
+        self.act = get_act_fn(config.head_class_act) if config.head_class_act else nn.Identity()
         self.norm = get_norm_layer(config) if config.head_class_norm else nn.Identity()
         self.drop = torch.nn.Dropout(config.head_class_dropout) if config.head_class_dropout > 0 else nn.Identity()
         self.pooling_type = config.pooling_type

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -46,6 +46,7 @@ model:
     normalization: rmsnorm
     padding: unpadded
     sparse_prediction: False
+    hidden_act: silu
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -46,6 +46,7 @@ model:
     normalization: rmsnorm
     padding: unpadded
     sparse_prediction: false
+    hidden_act: silu
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -50,6 +50,7 @@ model:
     rotary_emb_base: 10000.0
     rotary_emb_scale_base: null
     rotary_emb_interleaved: false
+    hidden_act: silu
 
 # Dataloaders
 train_loader:

--- a/yamls/models/flex_bert.yaml
+++ b/yamls/models/flex_bert.yaml
@@ -33,6 +33,7 @@ model:
     head_pred_bias: False
     head_pred_dropout: 0.0
     head_pred_norm: True
+    hidden_act: silu
     pooling_type: mean
     use_fa2: True
     use_sdpa_attn_mask: False


### PR DESCRIPTION
This PR introduces a number of fixes for the behavior of the models w.r.t the config and consistency across FlexBert and original MosaicBERT:

- The default pooling option is now `cls`, as it is the default for MosaicBERT
- FlexBERT MLP/GLU layers are now using the `config.hidden_act` parameter instead of relying on the default `config.activation_function`
- Prediction head of MosaicBERT is now using `config.head_pred_act` instead of `config.hidden_act` (edit: this would require adding head_pred_act to the MosaicBERT config, do we want to be able to define the activation for the pred head for Mosaic?)
- Prediction and classification heads are now using resp `config.head_pred_act` and `config.head_class_act` instead of relying on the default `config.activation_function`


Nb: to be consistent with MosaicBERT rn, the `head_class_act` of FlexBERT should be defined as Tanh and the `config.head_class_norm` should be explicitly set as None. Maybe we want to make this the default?
Also, we might want to change the Tanh activation to a `get_act_fn(config.head_class_act)`.

Also ; I find it a bit misleading to have different parameters for the normalization whereas we only read the default value. Either we want to add the string option to the get_norm or remove these different options (or put them as bool for toggling on/off the normalization to certain parts). 

Edit: for the MLP/GLU layers, maybe you had in mind that those should be defined by the actual `activation_function` parameter @warner-benjamin? I find it a bit misleading to have a new parameter instead of using the one used in MosaicBERT, so I think it should be `config.hidden_act`. The `activation_function` being a fallback (as it is not really well defined to me). Happy to discuss this.