### PR TITLE
Add weight decay filtering and StableAdamW

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,9 @@
 import os
 import sys
 from typing import Optional, cast
+import warnings
+
+from torch import nn
 
 # Add folder root to path to allow us to use relative imports regardless of what directory the script is run from
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
@@ -54,6 +57,24 @@ def update_batch_size_info(cfg: DictConfig):
         else:
             cfg.device_eval_batch_size = cfg.device_train_microbatch_size
     return cfg
+
+
+# from timm: https://github.com/huggingface/pytorch-image-models/blob/main/timm/optim/optim_factory.py
+# Copyright 2019 Ross Wightman, Apache-2.0 License
+def param_groups_weight_decay(model: nn.Module, weight_decay=1e-5, no_weight_decay_list=()):
+    no_weight_decay_list = set(no_weight_decay_list)
+    decay = []
+    no_decay = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+
+        if param.ndim <= 1 or name.endswith(".bias") or name in no_weight_decay_list:
+            no_decay.append(param)
+        else:
+            decay.append(param)
+
+    return [{"params": no_decay, "weight_decay": 0.0}, {"params": decay, "weight_decay": weight_decay}]
 
 
 def log_config(cfg: DictConfig):
@@ -118,17 +139,43 @@ def build_scheduler(cfg):
 
 
 def build_optimizer(cfg, model):
+    if cfg.get("filter_bias_and_bn", False):
+        params = param_groups_weight_decay(model, weight_decay=cfg.weight_decay)
+    else:
+        params = model.parameters()
+
     if cfg.name == "decoupled_adamw":
-        return DecoupledAdamW(
-            model.parameters(), lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay
-        )
+        return DecoupledAdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
     elif cfg.name == "adamw":
         print(
-                "INFO: You might want to increase the weight decay because in AdamW it is scaled by the lr."
-                f" Default weight decay is ``1e-2`` -> {cfg.weight_decay}. Default lr is `lr=1e-3` -> {cfg.lr}."
-            )
-        return AdamW(
-            model.parameters(), lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay
+            "INFO: You might want to increase the weight decay because in AdamW it is scaled by the lr."
+            f" Default weight decay is ``1e-2`` -> {cfg.weight_decay}. Default lr is `lr=1e-3` -> {cfg.lr}."
+        )
+        return AdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
+    elif cfg.name == "stableadamw":
+        try:
+            from optimi import StableAdamW
+        except ImportError:
+            raise ImportError("Install `pip install torch-optimi` to use the StableAdamW optimizer.")
+
+        print(
+            "INFO: You might want to increase the weight decay because in StableAdamW it is scaled by the lr."
+            f" Default weight decay is ``1e-2`` -> {cfg.weight_decay}. Default lr is `lr=1e-3` -> {cfg.lr}."
+        )
+        return StableAdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
+    elif cfg.name == "decoupled_stableadamw":
+        try:
+            from optimi import StableAdamW
+        except ImportError:
+            raise ImportError("Install `pip install torch-optimi` to use the StableAdamW optimizer.")
+
+        return StableAdamW(
+            params,
+            lr=cfg.lr,
+            betas=list(cfg.betas),
+            eps=cfg.eps,
+            weight_decay=cfg.weight_decay,
+            decouple_lr=True,
         )
     else:
         raise ValueError(f"Not sure how to build optimizer: {cfg.name}")
@@ -212,6 +259,14 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
     callbacks = [build_callback(name, callback_cfg) for name, callback_cfg in cfg.get("callbacks", {}).items()]
 
     # Algorithms
+    if (
+        cfg.get("algorithms", {}).get("gradient_clipping", {}).get("clipping_threshold", 0) > 0
+    ) and "stableadamw" in cfg.get("optimizer", {}).get("name", "adamw"):
+        warnings.warn(
+            f"The StableAdamW optimizer replaces gradient clipping. "
+            f"Set {cfg['algorithms']['gradient_clipping']['clipping_threshold']=} to 0.0"
+        )
+
     algorithms = [build_algorithm(name, algorithm_cfg) for name, algorithm_cfg in cfg.get("algorithms", {}).items()]
 
     if cfg.get("run_name") is None:

--- a/tests/smoketest_config_classification.yaml
+++ b/tests/smoketest_config_classification.yaml
@@ -41,6 +41,7 @@ optimizer:
   - 0.95
   eps: 1.0e-08
   weight_decay: 0.0
+  filter_bias_and_bn: false
 
 # Training duration and evaluation frequency
 max_duration: 8ba

--- a/tests/smoketest_config_main.yaml
+++ b/tests/smoketest_config_main.yaml
@@ -56,6 +56,7 @@ optimizer:
   - 0.95
   eps: 1.0e-08
   weight_decay: 0.0
+  filter_bias_and_bn: false
 
 # Training duration and evaluation frequency
 max_duration: 8ba
@@ -77,3 +78,8 @@ callbacks:
   speed_monitor:
     window_size: 4
   lr_monitor: {}
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0

--- a/tests/smoketest_config_sdpa_fa2.yaml
+++ b/tests/smoketest_config_sdpa_fa2.yaml
@@ -55,7 +55,8 @@ optimizer:
   - 0.9
   - 0.95
   eps: 1.0e-08
-  weight_decay: 0.0
+  weight_decay: 0.01
+  filter_bias_and_bn: true
 
 # Training duration and evaluation frequency
 max_duration: 8ba

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -24,7 +24,7 @@ model:
   model_config:
     num_attention_heads: 12 # bert-base default
     num_hidden_layers: 12 # bert-base default
-    attention_layer: parallel 
+    attention_layer: parallel
     attention_probs_dropout_prob: 0.0
     attn_out_bias: False
     attn_out_dropout_prob: 0.0
@@ -88,6 +88,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
+  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -88,6 +88,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
+  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -92,6 +92,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
+  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 

--- a/yamls/main/hf-bert-base-uncased.yaml
+++ b/yamls/main/hf-bert-base-uncased.yaml
@@ -69,6 +69,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
+  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
 
 max_duration: 286720000sp # Subsample the training data for ~275M samples
 eval_interval: 2000ba

--- a/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/yamls/main/mosaic-bert-base-uncased.yaml
@@ -67,6 +67,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
+  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 


### PR DESCRIPTION
This PR adds the [StableAdamW optimizer](https://arxiv.org/abs/2304.13013) as an option. It requires installing [optimi](https://github.com/warner-benjamin/optimi) `pip install torch-optimi`. StableAdamW removes the need for gradient clipping, and I've found it to be a pareto improvement over AdamW.

This PR also adds the `filter_bias_and_bn` option, which prevents weight decay from being applied to linear bias terms and normalization layers. I left it as false to match the current defaults (except in a test) but given its a best practice, we should use it for all of our training.