### PR TITLE
Default pretraining gradient clipping & bias/norm weight decay filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,7 +139,7 @@ def build_scheduler(cfg):
 
 
 def build_optimizer(cfg, model):
-    if cfg.get("filter_bias_and_bn", False):
+    if cfg.get("filter_bias_norm_wd", False):
         params = param_groups_weight_decay(model, weight_decay=cfg.weight_decay)
     else:
         params = model.parameters()

--- a/tests/smoketest_config_classification.yaml
+++ b/tests/smoketest_config_classification.yaml
@@ -41,7 +41,7 @@ optimizer:
   - 0.95
   eps: 1.0e-08
   weight_decay: 0.0
-  filter_bias_and_bn: false
+  filter_bias_norm_wd: false
 
 # Training duration and evaluation frequency
 max_duration: 8ba

--- a/tests/smoketest_config_main.yaml
+++ b/tests/smoketest_config_main.yaml
@@ -56,7 +56,7 @@ optimizer:
   - 0.95
   eps: 1.0e-08
   weight_decay: 0.0
-  filter_bias_and_bn: false
+  filter_bias_norm_wd: false
 
 # Training duration and evaluation frequency
 max_duration: 8ba

--- a/tests/smoketest_config_sdpa_fa2.yaml
+++ b/tests/smoketest_config_sdpa_fa2.yaml
@@ -56,7 +56,7 @@ optimizer:
   - 0.95
   eps: 1.0e-08
   weight_decay: 0.01
-  filter_bias_and_bn: true
+  filter_bias_norm_wd: true
 
 # Training duration and evaluation frequency
 max_duration: 8ba

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -89,7 +89,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
-  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
+  filter_bias_norm_wd: true # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 
@@ -113,6 +113,11 @@ callbacks:
   speed_monitor:
     window_size: 500
   lr_monitor: {}
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
 
 # (Optional) W&B logging
 loggers:

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -89,7 +89,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
-  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
+  filter_bias_norm_wd: true # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 
@@ -113,6 +113,11 @@ callbacks:
   speed_monitor:
     window_size: 500
   lr_monitor: {}
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
 
 # (Optional) W&B logging
 # loggers:

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -93,7 +93,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
-  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
+  filter_bias_norm_wd: true # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 
@@ -112,6 +112,11 @@ precision: amp_bf16
 progress_bar: false
 log_to_console: true
 console_log_interval: 1ba
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
 
 callbacks:
   speed_monitor:

--- a/yamls/main/hf-bert-base-uncased.yaml
+++ b/yamls/main/hf-bert-base-uncased.yaml
@@ -69,7 +69,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
-  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
+  filter_bias_norm_wd: false # If True, doesn't apply weight decay to norm layers and biases
 
 max_duration: 286720000sp # Subsample the training data for ~275M samples
 eval_interval: 2000ba
@@ -87,6 +87,10 @@ progress_bar: false
 log_to_console: true
 console_log_interval: 1ba
 
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
 
 callbacks:
   speed_monitor:

--- a/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/yamls/main/mosaic-bert-base-uncased.yaml
@@ -67,7 +67,7 @@ optimizer:
   - 0.98
   eps: 1.0e-06
   weight_decay: 1.0e-5 # Amount of weight decay regularization
-  filter_bias_and_bn: false # If True, doesn't apply weight decay to norm layers and biases
+  filter_bias_norm_wd: false # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:
 
@@ -91,6 +91,11 @@ callbacks:
   speed_monitor:
     window_size: 500
   lr_monitor: {}
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
 
 # (Optional) W&B logging
 # loggers:


### PR DESCRIPTION
This PR turns on gradient clipping at a conservative value of 1.0 and enables bias & normalization weight decay filtering for pretraining by default.

I also renamed the weight decay filter option name to hopefully be a bit more self-explanatory.