### PR TITLE
Fix GLUE tests

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -25,7 +25,6 @@ import src.hf_bert as hf_bert_module
 import src.mosaic_bert as mosaic_bert_module
 import src.flex_bert as flex_bert_module
 import torch
-import transformers
 from composer import algorithms
 from composer.callbacks import (
     LRMonitor,

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -651,6 +651,30 @@ class BertForMultipleChoice(BertPreTrainedModel):
             input_ids.shape[1] if input_ids is not None else inputs_embeds.shape[1]
         )
 
+        input_ids = (
+            input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
+        )
+        attention_mask = (
+            attention_mask.view(-1, attention_mask.size(-1))
+            if attention_mask is not None
+            else None
+        )
+        token_type_ids = (
+            token_type_ids.view(-1, token_type_ids.size(-1))
+            if token_type_ids is not None
+            else None
+        )
+        position_ids = (
+            position_ids.view(-1, position_ids.size(-1))
+            if position_ids is not None
+            else None
+        )
+        inputs_embeds = (
+            inputs_embeds.view(-1, inputs_embeds.size(-2), inputs_embeds.size(-1))
+            if inputs_embeds is not None
+            else None
+        )
+
         outputs = self.bert(
             input_ids,
             attention_mask=attention_mask,
@@ -1169,6 +1193,20 @@ class FlexBertForMultipleChoice(BertPreTrainedModel):
             return_dict if return_dict is not None else self.config.use_return_dict
         )
         num_choices = input_ids.shape[1]
+
+        input_ids = (
+            input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
+        )
+        attention_mask = (
+            attention_mask.view(-1, attention_mask.size(-1))
+            if attention_mask is not None
+            else None
+        )
+        position_ids = (
+            position_ids.view(-1, position_ids.size(-1))
+            if position_ids is not None
+            else None
+        )
 
         output = self.bert(
             input_ids,

--- a/src/evals/finetuning_jobs.py
+++ b/src/evals/finetuning_jobs.py
@@ -63,7 +63,7 @@ def build_dataloader(dataset, collate_fn=None, **kwargs):
 
     return DataLoader(
         dataset=dataset,
-        sampler=dist.get_sampler(dataset, drop_last=False, shuffle=False),
+        sampler=dist.get_sampler(dataset, drop_last=False, shuffle=True),
         collate_fn=(
             transformers.default_data_collator if collate_fn is None else collate_fn
         ),

--- a/src/evals/glue_jobs.py
+++ b/src/evals/glue_jobs.py
@@ -77,7 +77,6 @@ class MNLIJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -162,7 +161,6 @@ class RTEJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -235,7 +233,6 @@ class QQPJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -308,7 +305,6 @@ class COLAJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -381,7 +377,6 @@ class MRPCJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -454,7 +449,6 @@ class QNLIJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -527,7 +521,6 @@ class SST2Job(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -600,7 +593,6 @@ class STSBJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -110,7 +110,6 @@ class SWAGJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
 

--- a/src/evals/superglue_jobs.py
+++ b/src/evals/superglue_jobs.py
@@ -85,7 +85,6 @@ class BoolQJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_superglue_dataset(split="train", **dataset_kwargs)
@@ -177,7 +176,6 @@ class CBJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_superglue_dataset(split="train", **dataset_kwargs)
@@ -279,7 +277,6 @@ class COPAJob(ClassificationJob):
             "batch_size": self.batch_size,
             "collate_fn": multiple_choice_collate_fn,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
 
@@ -429,7 +426,6 @@ class MultiRCJob(ClassificationJob):
             "batch_size": self.batch_size,
             "collate_fn": collate_fn,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
 
@@ -505,7 +501,6 @@ class WiCJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_superglue_dataset(split="train", **dataset_kwargs)

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -111,8 +111,12 @@ def create_flex_bert_mlm(
     if "prenorm" in config.bert_layer:
         assert config.final_norm, "Final norm must be used with prenorm attention"
     else:
-        assert "postnorm" in config.bert_layer, "config.bert_layer str must contain either prenorm or postnorm"
-        assert not config.final_norm, "Final norm should not be used with postnorm attention"
+        assert (
+            "postnorm" in config.bert_layer
+        ), "config.bert_layer str must contain either prenorm or postnorm"
+        assert (
+            not config.final_norm
+        ), "Final norm should not be used with postnorm attention"
 
     # Padding for divisibility by 8
     if config.vocab_size % 8 != 0:
@@ -164,6 +168,7 @@ def create_flex_bert_classification(
     tokenizer_name: Optional[str] = None,
     gradient_checkpointing: Optional[bool] = False,
     pretrained_checkpoint: Optional[str] = None,
+    custom_eval_metrics: Optional[list] = [],
     multiple_choice: Optional[bool] = False,
 ):
     """FlexBERT classification model based on |:hugging_face:| Transformers.
@@ -189,6 +194,8 @@ def create_flex_bert_classification(
             initialize the model weights. If provided,
             the state dictionary stored at `pretrained_checkpoint` will be
             loaded into the model after initialization. Default: ``None``.
+        custom_eval_metrics (list, optional): Classes of custom metrics to
+            evaluate the model. Default: ``[]``.
         multiple_choice (bool, optional): Whether the model is used for
             multiple choice tasks. Default: ``False``.
 
@@ -311,6 +318,10 @@ def create_flex_bert_classification(
         tokenizer=tokenizer,
         use_logits=True,
         metrics=metrics,
+        eval_metrics=[
+            *metrics,
+            *[metric_cls() for metric_cls in custom_eval_metrics],
+        ],
         allow_embedding_resizing=model.config.allow_embedding_resizing,
     )
 

--- a/src/mosaic_bert.py
+++ b/src/mosaic_bert.py
@@ -146,6 +146,7 @@ def create_mosaic_bert_classification(
     tokenizer_name: Optional[str] = None,
     gradient_checkpointing: Optional[bool] = False,
     pretrained_checkpoint: Optional[str] = None,
+    custom_eval_metrics: Optional[list] = [],
     multiple_choice: Optional[bool] = False,
 ):
     """Mosaic BERT classification model based on |:hugging_face:| Transformers.
@@ -171,6 +172,8 @@ def create_mosaic_bert_classification(
             initialize the model weights. If provided,
             the state dictionary stored at `pretrained_checkpoint` will be
             loaded into the model after initialization. Default: ``None``.
+        custom_eval_metrics (list, optional): Classes of custom metrics to
+            evaluate the model. Default: ``[]``.
         multiple_choice (bool, optional): Whether the model is used for
             multiple choice tasks. Default: ``False``.
 
@@ -296,7 +299,14 @@ def create_mosaic_bert_classification(
             metrics.append(BinaryF1Score())
 
     hf_model = HuggingFaceModel(
-        model=model, tokenizer=tokenizer, use_logits=True, metrics=metrics
+        model=model,
+        tokenizer=tokenizer,
+        use_logits=True,
+        metrics=metrics,
+        eval_metrics=[
+            *metrics,
+            *[metric_cls() for metric_cls in custom_eval_metrics],
+        ],
     )
 
     # Padding for divisibility by 8

--- a/tests/smoketest_config_superglue.yaml
+++ b/tests/smoketest_config_superglue.yaml
@@ -43,10 +43,8 @@ tasks: # Only run SWAG and COPA for the sake of testing
       save_num_checkpoints_to_keep: 1
       max_duration: 2ba
       eval_subset_num_batches: 2
-      device_train_microbatch_size: 2
   copa:
     trainer_kwargs:
       save_num_checkpoints_to_keep: 0
       max_duration: 2ba
       eval_subset_num_batches: 2
-      device_train_microbatch_size: 2

--- a/tests/smoketest_config_superglue.yaml
+++ b/tests/smoketest_config_superglue.yaml
@@ -2,7 +2,7 @@
 parallel: false
 
 # Basic run configuration, additional details will be added to this name for each GLUE task, and each random seed
-base_run_name: glue-finetuning-benchmark-test
+base_run_name: superglue-finetuning-benchmark-test
 default_seed: 1111
 precision: fp32
 
@@ -34,17 +34,19 @@ scheduler:
   alpha_f: 0.0
 
 # Task configuration
-tasks: # Only run MNLI and RTE for the sake of testing
-  mnli:
+tasks: # Only run SWAG and COPA for the sake of testing
+  swag:
     # Specify any extra task-specific arguments for the trainer here
     trainer_kwargs:
-      # We keep one MNLI checkpoint locally so that we can start finetuning of
-      # RTE, MRPC and STS-B from the MNLI checkpoint
+      # We keep one SWAG checkpoint locally so that we can start finetuning of
+      # COPA from the SWAG checkpoint
       save_num_checkpoints_to_keep: 1
       max_duration: 2ba
       eval_subset_num_batches: 2
-  rte:
+      device_train_microbatch_size: 2
+  copa:
     trainer_kwargs:
       save_num_checkpoints_to_keep: 0
       max_duration: 2ba
       eval_subset_num_batches: 2
+      device_train_microbatch_size: 2

--- a/tests/test_superglue.py
+++ b/tests/test_superglue.py
@@ -31,7 +31,7 @@ class SuperGlueDirContext(object):
             shutil.rmtree(self.path)
 
 
-@pytest.mark.parametrize("model_name", ["mosaic_bert"])
+@pytest.mark.parametrize("model_name", ["mosaic_bert", "hf_bert", "flex_bert"])
 def test_superglue_script(model_name: str):
     with open("yamls/defaults.yaml") as f:
         default_cfg = OmegaConf.load(f)

--- a/tests/test_superglue.py
+++ b/tests/test_superglue.py
@@ -1,0 +1,56 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import os
+import shutil
+import tempfile
+from typing import Any
+
+import pytest
+
+# Add tests folder root to path to allow us to use relative imports regardless of what directory the script is run from
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+# Add folder root to path to allow us to use relative imports regardless of what directory the script is run from
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from glue import train
+from omegaconf import DictConfig, OmegaConf
+
+
+class SuperGlueDirContext(object):
+    def __init__(self):
+        self.path = None
+
+    def __enter__(self):
+        self.path = tempfile.mkdtemp()
+        return self.path
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        del exc_type, exc_value, traceback  # unused
+        if self.path is not None:
+            shutil.rmtree(self.path)
+
+
+@pytest.mark.parametrize("model_name", ["mosaic_bert"])
+def test_superglue_script(model_name: str):
+    with open("yamls/defaults.yaml") as f:
+        default_cfg = OmegaConf.load(f)
+    with open(f"yamls/models/{model_name}.yaml") as f:
+        model_cfg = OmegaConf.load(f)
+    with open("tests/smoketest_config_superglue.yaml") as f:
+        test_config = OmegaConf.load(f)
+    config = OmegaConf.merge(default_cfg, model_cfg, test_config)
+    assert isinstance(config, DictConfig)
+    config.model.name = model_name
+
+    if (
+        model_name == "flex_bert"
+        and not config.model.model_config.use_fa2
+        and config.model.model_config.padding == "unpadded"
+    ):
+        pytest.skip("SDPA call currently errors with SuperGlue test on unpadded inputs")
+
+    # The test is that `train` runs successfully
+    with SuperGlueDirContext() as local_save_dir:
+        config.save_finetune_checkpoint_prefix = local_save_dir
+        train(config)


### PR DESCRIPTION
This PR fixes the tests in `tests/test_glue.py`, following discussion in #55. Following up on some comments in #34, I've realized why `shuffle` was originally set to `False` in all of our tasks: it can't be set to `True` when `sampler` is also in use ([link](https://github.com/AnswerDotAI/bert24/compare/jack/glue-test-fix?expand=1#diff-4e712b4f552bf50782daee44ac62ae57c1543620699bd4f4788aedff7340d8b2R66)).

I also added smoketests for SuperGLUE, however the tests in this file are currently failing due to an issue involving our unpadding implementation. The issue has to do with the inputs for multiple choice tasks: e.g. when using `BertForMultipleChoice`, rather than passing in inputs of shape `(B S)` (batch size, seq length), we need to be able to pass in inputs of shape `(B C S)` (batch size, multiple choice options, seq length). This results in a CUDA indexing error in the `torch.gather` call on line 35 of `src/bert_padding.py`. I unfortunately don't have enough time to debug and fix it right now, and would really appreciate some help with it -- I figured it would be worth making the PR anyway to fix the GLUE tests in the meantime.