### PR TITLE
Add OLMo Model Initialization Options

### DIFF
--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -73,7 +73,7 @@ class FlexBertConfig(TransformersBertConfig):
         use_fa2: bool = True,
         use_sdpa_attn_mask: bool = False,
         allow_embedding_resizing: bool = False,
-        init_method: str = "normal",
+        init_method: str = "default",
         init_std: float = 0.02,
         init_cutoff_factor: float = 2.0,
         init_small_embedding: bool = False,

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -73,6 +73,10 @@ class FlexBertConfig(TransformersBertConfig):
         use_fa2: bool = True,
         use_sdpa_attn_mask: bool = False,
         allow_embedding_resizing: bool = False,
+        init_method: str = "normal",
+        init_std: float = 0.02,
+        init_cutoff_factor: float = 2.0,
+        init_small_embedding: bool = False,
         **kwargs,
     ):
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
@@ -113,6 +117,10 @@ class FlexBertConfig(TransformersBertConfig):
         self.use_fa2 = use_fa2
         self.use_sdpa_attn_mask = use_sdpa_attn_mask
         self.allow_embedding_resizing = allow_embedding_resizing
+        self.init_method = init_method
+        self.init_std = init_std
+        self.init_cutoff_factor = init_cutoff_factor
+        self.init_small_embedding = init_small_embedding
 
 
 PADDING = ["unpadded", "padded"]

--- a/src/bert_layers/initialization.py
+++ b/src/bert_layers/initialization.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 from src.utils import StrEnum
 from .configuration_bert import FlexBertConfig
 
-__all__ = ["init_weights", "ModuleType"]
+__all__ = ["init_weights", "ModuleType", "InitFnType"]
 
 
 class InitFnType(StrEnum):
@@ -144,20 +144,3 @@ def init_weights(
 
     if isinstance(module, nn.Embedding) and config.init_small_embedding:
         nn.init.uniform_(module.weight, a=-1e-4, b=1e-4)
-
-
-def init_normal(
-    module: Union[nn.Linear, nn.Embedding],
-    std: float,
-    init_cutoff_factor: Optional[float] = None,
-):
-    # weights
-    if init_cutoff_factor is not None:
-        cutoff_value = init_cutoff_factor * std
-        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
-    else:
-        nn.init.normal_(module.weight, mean=0.0, std=std)
-
-    # biases
-    if isinstance(module, nn.Linear) and module.bias is not None:
-        nn.init.zeros_(module.bias)

--- a/src/bert_layers/initialization.py
+++ b/src/bert_layers/initialization.py
@@ -29,6 +29,11 @@ class InitFnType(StrEnum):
     All weights are initialized from the same normal distribution.
     """
 
+    default = "default"
+    """
+    All weights are initialized with the default method from PyTorch.
+    """
+
     kaiming_normal = "kaiming_normal"
     """
     All weights are initialized with the Kaiming method from a normal distribution.
@@ -124,6 +129,8 @@ def init_weights(
             a=-cutoff_factor * std,
             b=cutoff_factor * std,
         )
+    elif config.init_method == InitFnType.default:
+        module.reset_parameters()
     else:
         raise NotImplementedError(config.init_method)
 

--- a/src/bert_layers/initialization.py
+++ b/src/bert_layers/initialization.py
@@ -1,0 +1,156 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2023 OLMo Authors
+# License: Apache-2.0
+
+import math
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+
+from src.utils import StrEnum
+from .configuration_bert import FlexBertConfig
+
+__all__ = ["init_weights", "ModuleType"]
+
+
+class InitFnType(StrEnum):
+    mitchell = "mitchell"
+    """
+    The strategy suggested to us by Mitchell Wortsman from UW.
+    This uses a truncated normal distribution with an adaptive standard deviation that depends
+    on the size of the weights as well as the depth of the layer.
+    """
+
+    normal = "normal"
+    """
+    All weights are initialized from the same normal distribution.
+    """
+
+    kaiming_normal = "kaiming_normal"
+    """
+    All weights are initialized with the Kaiming method from a normal distribution.
+    Note this currently won't work with FSDP.
+    """
+
+    fan_in = "fan_in"
+    """
+    "Fan-in variance scaling", i.e. normal with a standard deviation of ``1/sqrt(d_in)`` where ``d_in``
+    is the input dimensionality of the kernel.
+    """
+
+    full_megatron = "full_megatron"
+    """
+    This is what metaseq calls "full megatron init". It is the init used for Llama 2.
+    """
+
+
+class ModuleType(StrEnum):
+    in_module = "in"
+    out_module = "out"
+    emb = "emb"
+    final_out = "final_out"
+
+
+def init_weights(
+    config: FlexBertConfig,
+    module: Union[nn.Linear, nn.Embedding],
+    layer_dim: Optional[int] = None,
+    layer_id: Optional[int] = None,
+    std_factor: float = 1.0,
+    type_of_module: Optional[ModuleType] = None,
+) -> None:
+    """
+    Initialize weights of a linear or embedding module.
+
+    :param config: The model config.
+    :param module: The linear or embedding submodule to initialize.
+    :param layer_dim: The effective input dimensionality of the weights. This could be smaller than the actual dimensions
+        for fused layers.
+    :param layer_id: When set, the standard deviation for the "mitchell" method will be adjusted by
+        ``1 / sqrt(2 * (layer_id + 1))``.
+    """
+    if config.init_method == InitFnType.full_megatron and config.init_small_embedding:
+        raise ValueError("Cannot use 'small_embedding_init' with 'full_megatron' init.")
+
+    layer_dim = layer_dim if layer_dim is not None else config.hidden_size
+    if config.init_method == InitFnType.normal:
+        std = config.init_std * std_factor
+        if config.init_cutoff_factor is not None:
+            cutoff_value = config.init_cutoff_factor * std
+            nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
+        else:
+            nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_method == InitFnType.mitchell:
+        std = std_factor / math.sqrt(layer_dim)
+        if layer_id is not None:
+            std = std / math.sqrt(2 * (layer_id + 1))
+        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
+    elif config.init_method == InitFnType.kaiming_normal:
+        nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
+    elif config.init_method == InitFnType.fan_in:
+        std = std_factor / math.sqrt(layer_dim)
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_method == InitFnType.full_megatron:
+        if type_of_module is None:
+            raise RuntimeError(f"When using the {InitFnType.full_megatron} init, every module must have a type.")
+
+        cutoff_factor = config.init_cutoff_factor
+        if cutoff_factor is None:
+            cutoff_factor = 3
+
+        if type_of_module == ModuleType.in_module:
+            # for att_proj (same as QKV), ff_proj
+            std = config.init_std
+        elif type_of_module == ModuleType.out_module:
+            # for attn_out, ff_out
+            std = config.init_std / math.sqrt(2.0 * config.n_layers)
+        elif type_of_module == ModuleType.emb:
+            # positional embeddings (wpe)
+            # token embeddings (wte)
+            std = config.init_std
+        elif type_of_module == ModuleType.final_out:
+            # final output (ff_out)
+            std = config.hidden_size**-0.5
+        else:
+            raise RuntimeError(f"Unknown module type '{type_of_module}'")
+
+        nn.init.trunc_normal_(
+            module.weight,
+            mean=0.0,
+            std=std,
+            a=-cutoff_factor * std,
+            b=cutoff_factor * std,
+        )
+    else:
+        raise NotImplementedError(config.init_method)
+
+    if isinstance(module, nn.Linear):
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+
+        if config.init_method == InitFnType.normal and getattr(module, "_is_residual", False):
+            with torch.no_grad():
+                module.weight.div_(math.sqrt(2 * config.n_layers))
+
+    if isinstance(module, nn.Embedding) and config.init_small_embedding:
+        nn.init.uniform_(module.weight, a=-1e-4, b=1e-4)
+
+
+def init_normal(
+    module: Union[nn.Linear, nn.Embedding],
+    std: float,
+    init_cutoff_factor: Optional[float] = None,
+):
+    # weights
+    if init_cutoff_factor is not None:
+        cutoff_value = init_cutoff_factor * std
+        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
+    else:
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+
+    # biases
+    if isinstance(module, nn.Linear) and module.bias is not None:
+        nn.init.zeros_(module.bias)

--- a/src/bert_layers/normalization.py
+++ b/src/bert_layers/normalization.py
@@ -10,6 +10,7 @@ import inspect
 import warnings
 import torch
 import torch.nn as nn
+from torch.nn import init
 
 from .configuration_bert import FlexBertConfig
 
@@ -60,6 +61,9 @@ class RMSNorm(nn.Module):
         """
         output = self._norm(x.float()).type_as(x)
         return output * self.weight
+
+    def reset_parameters(self):
+        init.ones_(self.weight)
 
 
 NORM2CLS = {

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,12 @@
 # Copyright 2020 Optuna, Hugging Face
 # License: Apache-2.0
 
+# Copyright 2023 OLMo Authors
+# License: Apache-2.0
+
 import functools
 import logging
+from enum import Enum
 
 
 @functools.lru_cache(None)
@@ -19,3 +23,16 @@ def warning_once(self, *args, **kwargs):
 
 logging.Logger.warning_once = warning_once
 logging.Logger.warn_once = warning_once
+
+
+class StrEnum(str, Enum):
+    """
+    This is equivalent to Python's :class:`enum.StrEnum` since version 3.11.
+    We include this here for compatibility with older version of Python.
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return f"'{str(self)}'"

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import random
 
 import pytest
 import torch
@@ -14,6 +15,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from main import main
 from test_utils import SynthTextDirectory
+from src.bert_layers.initialization import InitFnType
 
 IMPL_USE_FLASH2 = False
 try:
@@ -55,6 +57,11 @@ def test_trainer(padding: str, layer: str, embedding: str, attention: str, mlp: 
     config.model.model_config.mlp_layer = mlp
     if layer == "postnorm":
         config.model.model_config.final_norm = False
+
+    # pick a random init type for testing
+    config.model.model_config.init_fn = random.choice([member.value for member in InitFnType])
+    if config.model.model_config.init_fn != InitFnType.full_megatron:
+        config.model.model_config.init_small_embedding = random.choice([True, False])
 
     with SynthTextDirectory() as tmp_datadir:
         config.model.model_config.use_fa2 = False

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -47,6 +47,10 @@ model:
     padding: unpadded
     sparse_prediction: False
     hidden_act: silu
+    init_method: normal
+    init_std: 0.02
+    init_cutoff_factor: 2.0
+    init_small_embedding: False
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -47,7 +47,7 @@ model:
     padding: unpadded
     sparse_prediction: False
     hidden_act: silu
-    init_method: normal
+    init_method: default
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -47,7 +47,7 @@ model:
     padding: unpadded
     sparse_prediction: false
     hidden_act: silu
-    init_method: normal
+    init_method: default
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -47,6 +47,10 @@ model:
     padding: unpadded
     sparse_prediction: false
     hidden_act: silu
+    init_method: normal
+    init_std: 0.02
+    init_cutoff_factor: 2.0
+    init_small_embedding: False
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -51,6 +51,10 @@ model:
     rotary_emb_scale_base: null
     rotary_emb_interleaved: false
     hidden_act: silu
+    init_method: normal
+    init_std: 0.02
+    init_cutoff_factor: 2.0
+    init_small_embedding: False
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -51,7 +51,7 @@ model:
     rotary_emb_scale_base: null
     rotary_emb_interleaved: false
     hidden_act: silu
-    init_method: normal
+    init_method: default
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False


### PR DESCRIPTION
This PR adds multiple standard model weight initialization options, including defaults such as normal & Kaiming, fan in, Megatron, and Mitchell. Mitchell is used by OLMo and Megatron is used by models like Lama 2, (I believe) Pythia, etc.

I also added support for [RWKV small embedding initialization](https://github.com/BlinkDL/SmallInitEmb), which looks like a useful way to speed up the initial training of the embedding weights. (It is not compatible with Megatron init).

Also, model.py apparently wasn't ruff formatted before, but it is now.