### PR TITLE
Add support for TritonRMS Norm

### DIFF
--- a/src/bert_layers/normalization.py
+++ b/src/bert_layers/normalization.py
@@ -12,6 +12,11 @@ import torch
 import torch.nn as nn
 
 from .configuration_bert import FlexBertConfig
+try:
+    from flash_attn.ops.triton.layer_norm import RMSNorm as TritonRMSNorm
+
+except ImportError:
+    TritonRMSNorm = None
 
 
 class RMSNorm(nn.Module):
@@ -64,7 +69,7 @@ class RMSNorm(nn.Module):
 
 NORM2CLS = {
     "layernorm": nn.LayerNorm,
-    "rmsnorm": RMSNorm,
+    "rmsnorm": RMSNorm if TritonRMSNorm is None else TritonRMSNorm,
 }
 
 

--- a/src/bert_layers/normalization.py
+++ b/src/bert_layers/normalization.py
@@ -22,7 +22,7 @@ except ImportError:
 class RMSNorm(nn.Module):
     """Llama2 RMSNorm implementation"""
 
-    def __init__(self, dim: int, eps: float = 1e-6):
+    def __init__(self, dim: int, eps: float = 1e-5):
         """
         Initialize the RMSNorm normalization layer.
 


### PR DESCRIPTION
This PR makes the RMS Norm faster and more memory efficient through adding support for a Triton RMS implementation, that is used when the flash-attention module is installed.

When quickly tested on a RTXA6000, the Triton RMSNorm gives the following improvements
-  ~ 15 % faster than current RMSNorm from Llama 2 repo, and more memory efficient
- ~ 0-2 % faster than the PyTorch implementation of the Standard layer norm, however with a very small increase in memory usage

Additionally I align the default of the current RMSNorm's eps-value with  TritonRMS and PyTorch standard layer norm