### PR TITLE
Add Triton RMSNorm kernel and low precision RMSNorm

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    triton: run triton kernel tests (deselect with '-m "not triton"')

--- a/src/bert_layers/triton/rmsnorm.py
+++ b/src/bert_layers/triton/rmsnorm.py
@@ -1,0 +1,254 @@
+# Copyright 2024 **AUTHORS_TODO**
+# License: Apache-2.0
+
+# Copyright (c) 2024, Tri Dao.
+# Apache-2.0 license
+# Modified from Mamba LayerNorm/RMSNorm https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/triton/layer_norm.py
+
+# Based on the Triton LayerNorm tutorial: https://triton-lang.org/main/getting-started/tutorials/05-layer-norm.html
+# For the backward pass, we keep weight_grad and bias_grad in registers and accumulate.
+# This is faster for dimensions up to 8k, but after that it's much slower due to register spilling.
+# The models we train have hidden dim up to 8k anyway (e.g. Llama 70B), so this is fine.
+
+import math
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+        triton.Config({}, num_warps=16),
+        triton.Config({}, num_warps=32),
+    ],
+    key=["N", "BLOCK_N"],
+)
+@triton.jit
+def _rms_norm_fwd_kernel(
+    X,  # pointer to the input
+    Y,  # pointer to the output
+    W,  # pointer to the weights
+    Rstd,  # pointer to the 1/std
+    stride_x_row,  # how much to increase the pointer when moving by 1 row
+    stride_y_row,
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    low_precision: tl.constexpr,  # if true, doesn't upcast the RMSNorm calculation to float32
+    BLOCK_N: tl.constexpr,
+):
+    # Map the program id to the row of X and Y it should compute.
+    row = tl.program_id(0)
+    X += row * stride_x_row
+    Y += row * stride_y_row
+
+    # Compute mean and variance
+    cols = tl.arange(0, BLOCK_N)
+    if low_precision:
+        x = tl.load(X + cols, mask=cols < N, other=0.0)
+    else:
+        x = tl.load(X + cols, mask=cols < N, other=0.0).to(tl.float32)
+
+    xbar = tl.where(cols < N, x, 0.0)
+    var = tl.sum(xbar * xbar, axis=0) / N
+    rstd = 1 / tl.sqrt(var + eps)
+    tl.store(Rstd + row, rstd)
+
+    # Normalize and apply linear transformation
+    mask = cols < N
+    if low_precision:
+        w = tl.load(W + cols, mask=mask)
+    else:
+        w = tl.load(W + cols, mask=mask).to(tl.float32)
+    x_hat = x * rstd
+    y = x_hat * w
+
+    # Write output
+    tl.store(Y + cols, y, mask=mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+        triton.Config({}, num_warps=16),
+        triton.Config({}, num_warps=32),
+    ],
+    key=["N", "BLOCK_N"],
+)
+@triton.jit
+def _rms_norm_bwd_kernel(
+    X,  # pointer to the input
+    W,  # pointer to the weights
+    DY,  # pointer to the output gradient
+    DX,  # pointer to the input gradient
+    DW,  # pointer to the partial sum of weights gradient
+    Rstd,  # pointer to the 1/std
+    stride_x_row,  # how much to increase the pointer when moving by 1 row
+    stride_dy_row,
+    stride_dx_row,
+    M,  # number of rows in X
+    N,  # number of columns in X
+    rows_per_program,
+    low_precision: tl.constexpr,  # if true, doesn't upcast the RMSNorm calculation to float32
+    BLOCK_N: tl.constexpr,
+):
+    # Map the program id to the elements of X, DX, and DY it should compute
+    row_block_id = tl.program_id(0)
+    row_start = row_block_id * rows_per_program
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < N
+
+    # Compute the pointers and load the weights for the current block
+    X += row_start * stride_x_row
+    DY += row_start * stride_dy_row
+    DX += row_start * stride_dx_row
+    if low_precision:
+        w = tl.load(W + cols, mask=mask)
+    else:
+        w = tl.load(W + cols, mask=mask).to(tl.float32)
+
+    # Initialize the partial sum of weights gradient for the current block
+    dw = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    # Compute the end row for the current block
+    row_end = min((row_block_id + 1) * rows_per_program, M)
+
+    # Iterate over the rows in the current block
+    for row in range(row_start, row_end):
+        # Load the input, output gradient, and 1/std for the current row
+        if low_precision:
+            x = tl.load(X + cols, mask=mask, other=0)
+            dy = tl.load(DY + cols, mask=mask, other=0)
+        else:
+            x = tl.load(X + cols, mask=mask, other=0).to(tl.float32)
+            dy = tl.load(DY + cols, mask=mask, other=0).to(tl.float32)
+        rstd = tl.load(Rstd + row)
+
+        # Compute the normalized input (xhat) and the element-wise product of weights and output gradient (wdy)
+        xhat = x * rstd
+        xhat = tl.where(mask, xhat, 0.0)
+        wdy = w * dy
+
+        # Accumulate the partial sum of weights gradient and compute the sum of element-wise product of xhat and wdy
+        dw += dy * xhat
+        c1 = tl.sum(xhat * wdy, axis=0) / N
+
+        # Compute the input gradient and store it for the current row
+        dx = (wdy - xhat * c1) * rstd
+        tl.store(DX + cols, dx, mask=mask)
+
+        # Update the pointers for the next row
+        X += stride_x_row
+        DY += stride_dy_row
+        DX += stride_dx_row
+
+    # Store the partial sum of weights gradient for the current block
+    tl.store(DW + row_block_id * N + cols, dw, mask=mask)
+
+
+class ApplyRMSNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, weight, eps=1e-6, low_precision=False):
+        x_shape_og = x.shape
+        # reshape input data into 2D tensor
+        x = x.view(-1, x.shape[-1])
+        n_rows, n_cols = x.shape
+
+        y = torch.empty_like(x)
+        rstd = torch.empty((n_rows,), dtype=x.dtype if low_precision else torch.float32, device=x.device)
+
+        # Less than 64KB per feature: enqueue fused kernel
+        MAX_FUSED_SIZE = 65536 // x.element_size()
+        BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(x.shape[-1]))
+        if n_cols > BLOCK_N:
+            raise RuntimeError("This RMSNorm doesn't support feature dim >= 64KB.")
+
+        # Enqueue kernel
+        _rms_norm_fwd_kernel[(n_rows,)](
+            x,
+            y,
+            weight,
+            rstd,
+            x.stride(0),
+            y.stride(0),
+            n_cols,
+            eps,
+            low_precision,
+            BLOCK_N=BLOCK_N,
+        )
+
+        ctx.save_for_backward(x, weight, rstd)
+        ctx.BLOCK_N = BLOCK_N
+        ctx.eps = eps
+        ctx.low_precision = low_precision
+        ctx.x_shape_og = x_shape_og
+
+        return y.view(x_shape_og)
+
+    @staticmethod
+    def backward(ctx, dy):
+        x, weight, rstd = ctx.saved_tensors
+        dy = dy.view(-1, dy.shape[-1])
+        if dy.stride(-1) != 1:
+            dy = dy.contiguous()
+        assert dy.shape == x.shape
+
+        dx = torch.empty_like(dy)
+
+        # Enqueue kernel using Triton
+        M, N = dy.shape
+        sm_count = torch.cuda.get_device_properties(dy.device).multi_processor_count
+        _dw = torch.empty(
+            (sm_count, N), dtype=weight.dtype if ctx.low_precision else torch.float32, device=weight.device
+        )
+        rows_per_program = math.ceil(M / sm_count)
+        _rms_norm_bwd_kernel[(sm_count,)](
+            x,
+            weight,
+            dy,
+            dx,
+            _dw,
+            rstd,
+            x.stride(0),
+            dy.stride(0),
+            dx.stride(0),
+            M,
+            N,
+            rows_per_program,
+            ctx.low_precision,
+            BLOCK_N=ctx.BLOCK_N,
+        )
+
+        dw = _dw.sum(0).to(weight.dtype)
+        return dx.view(ctx.x_shape_og), dw, None, None
+
+
+class TritonRMSNorm(torch.nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-5,
+        low_precision: bool = False,
+        device: torch.device = None,
+        dtype: torch.dtype = None,
+    ):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.eps = eps
+        self.low_precision = low_precision
+        self.weight = torch.nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        torch.nn.init.ones_(self.weight)
+
+    def forward(self, x: torch.Tensor):
+        return ApplyRMSNorm.apply(x, self.weight, self.eps, self.low_precision)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-triton",
+        action="store_true",
+        help="run the tests only in case of that command line (marked with marker @no_cmd)",
+    )
+
+
+def pytest_runtest_setup(item):
+    if "triton" in item.keywords and not item.config.getoption("--run-triton"):
+        pytest.skip("pass --run_triton option to run this test")

--- a/tests/test_rmsnorm.py
+++ b/tests/test_rmsnorm.py
@@ -1,0 +1,95 @@
+# Test modified from attorch
+# Copyright (c) 2023 Borna Ahmadzadeh
+# SPDX-License-Identifier: MIT
+
+
+from typing import Tuple
+
+import pytest
+import torch
+from torch.cuda.amp import autocast
+
+from src.bert_layers.normalization import RMSNorm
+from src.bert_layers.triton.rmsnorm import TritonRMSNorm
+
+
+def assert_most_approx_close(a, b, rtol=1e-3, atol=1e-3, max_error_count=0, max_error_rate=None, name=""):
+    idx = torch.isclose(a, b, rtol=rtol, atol=atol)
+    error_count = (idx == 0).sum().item()
+    if max_error_rate is not None:
+        total_elements = torch.prod(torch.tensor(a.shape))
+        if error_count > total_elements * max_error_rate and error_count > max_error_count:
+            print(f"{name}Too many values not close: assert {error_count} < {total_elements * max_error_rate}")
+            torch.testing.assert_close(a, b, rtol=rtol, atol=atol)
+    elif error_count > max_error_count:
+        print(f"{name}Too many values not close: assert {error_count} < {max_error_count}")
+        torch.testing.assert_close(a, b, rtol=rtol, atol=atol)
+
+
+is_sm8x = torch.cuda.get_device_capability("cuda") >= (8, 0)
+
+
+@pytest.mark.parametrize("shape", [(128,), (1024,), (2048, 768), (2048, 2048), (16, 256, 512)])
+@pytest.mark.parametrize("eps", [1e-5, 1e-6])
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.float16] if not is_sm8x else [torch.float32, torch.float16, torch.bfloat16]
+)
+@pytest.mark.parametrize("low_precision", [True, False])
+@pytest.mark.parametrize("amp", [False, True])
+@pytest.mark.triton
+def test_rmsnorm_layer(
+    shape: Tuple[int, ...],
+    eps: float,
+    dtype: bool,
+    low_precision: bool,
+    amp: bool,
+) -> None:
+    if dtype is torch.float16 and not amp:
+        pytest.skip("Skipping fp16 test without autocast enabled")
+    if dtype == torch.float32 and low_precision:
+        pytest.skip("Skipping fp32 test with low precision enabled")
+
+    if dtype == torch.float32:
+        atol, rtol = 2e-5, 2e-5  # tests don't always pass at the usual 1e-6, 1e-5, small percentage of params are off
+    elif dtype == torch.bfloat16:
+        atol, rtol = (5e-3, 5e-2) if low_precision else (1e-3, 1e-2)
+    elif dtype == torch.float16:
+        atol, rtol = (5e-4, 5e-3) if low_precision else (1e-4, 1e-3)
+
+    triton_input = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
+    pytorch_input = triton_input.detach().clone().requires_grad_(True)
+
+    triton_rmsnorm = TritonRMSNorm(shape[-1], eps=eps, device="cuda", dtype=dtype, low_precision=low_precision)
+    pytorch_rmsnorm = RMSNorm(shape[-1], eps=eps, device="cuda", dtype=dtype, low_precision=low_precision)
+
+    with autocast(enabled=amp, dtype=dtype):
+        triton_output = triton_rmsnorm(triton_input)
+        pytorch_output = pytorch_rmsnorm(pytorch_input)
+
+    assert (
+        triton_output.dtype == pytorch_output.dtype
+    ), f"dtypes do not match, {triton_output.dtype=}, {pytorch_output.dtype=}"
+    assert triton_output.dtype == dtype, f"dtypes do not match, {triton_output.dtype=}, {dtype=}"
+    torch.testing.assert_close(triton_output, pytorch_output, rtol=rtol, atol=atol)
+
+    grad = torch.rand_like(triton_output)
+    triton_output.backward(grad)
+    pytorch_output.backward(grad)
+
+    assert_most_approx_close(
+        triton_rmsnorm.weight.grad,
+        pytorch_rmsnorm.weight.grad,
+        rtol=rtol,
+        atol=atol,
+        max_error_rate=0.06 if low_precision else 0,
+        name=f"weight gradients do not match {shape=}, {dtype=}, {amp=}, {low_precision=}, {eps=}",
+    )
+
+    assert_most_approx_close(
+        triton_input.grad,
+        pytorch_input.grad,
+        rtol=rtol,
+        atol=atol,
+        max_error_rate=0.06 if low_precision else 0,
+        name=f"input gradients do not match {shape=}, {dtype=}, {amp=}, {low_precision=}, {eps=}",
+    )


### PR DESCRIPTION
Like #62 this PR adds a Triton RMSNorm kernel, but without flash_attn. It is simplified and modified from the [Mamba RMSNorm kernel](https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/triton/layer_norm.py) with support for low precision RMSNorm.

Unlike Mosaic's low precision LayerNorm, low precision Triton RMSNorm doesn't appear to be any faster on consumer hardware, it's usuall a bit slower than the FP32 version. At least when tested by itself.

Feel free to close this in favor of #62 if preferred. Checking in the code since I had it almost finished.

FP32 benchmarks between TritonRMSNorm  and the current PyTorch Eager RMSNorm kernel.
<details>
Input shape: (16, Seqlen, 760)

```
    SeqLen  TritonRMSNorm  TorchRMSNorm
0    256.0     511.999982    234.802544
1    512.0     571.534916    165.309420
2    768.0     654.874887    132.923078
3   1024.0     667.268923    124.889953
4   1280.0     728.537533    118.533765
5   1536.0     729.980179    119.048135
6   1792.0     765.721057    119.245844
7   2048.0     780.513133    119.397573
8   2304.0     803.331716    119.466093
9   2560.0     818.007065    119.494328
10  2816.0     824.352204    119.652996
11  3072.0     836.234386    119.720705
12  3328.0     834.898947    119.897925
13  3584.0     843.768077    119.994422
14  3840.0     851.157777    120.078178
15  4096.0     859.801768    120.200533
16  4352.0     854.963173    120.216385
17  4608.0     858.411376    120.295865
18  4864.0     860.461887    120.367077
19  5120.0     865.352086    120.313625
20  5376.0     866.811563    120.414376
21  5632.0     864.614088    120.438164
22  5888.0     872.969881    120.454011
23  6144.0     880.334355    114.662982
24  6400.0     880.229179    120.487573
25  6656.0     878.518756    120.463015
26  6912.0     880.821247    120.499764
27  7168.0     875.480906    120.525100
28  7424.0     884.980131    120.497752
29  7680.0     886.153877    120.457463
30  7936.0     840.861990    120.521409
31  8192.0     882.309614    120.569092
```
Input shape: (16, Seqlen, 1024)

```
    SeqLen  TritonRMSNorm  TorchRMSNorm
0    256.0     599.414644    214.637557
1    512.0     733.611931    140.481321
2    768.0     712.347810    125.387756
3   1024.0     805.409485    118.865955
4   1280.0     830.270234    119.243080
5   1536.0     830.738036    119.397573
6   1792.0     854.353062    119.466665
7   2048.0     858.550228    119.591245
8   2304.0     865.690817    119.785542
9   2560.0     868.409890    119.970704
10  2816.0     880.931951    120.060123
11  3072.0     873.166516    120.211633
12  3328.0     887.466653    120.289158
13  3584.0     889.072232    120.344181
14  3840.0     886.153856    120.394664
15  4096.0     892.658328    120.433693
16  4352.0     892.717924    120.496642
17  4608.0     890.972815    120.437788
18  4864.0     896.245666    120.486129
19  5120.0     847.265642    120.509819
20  5376.0     889.820701    120.498722
21  5632.0     898.872845    120.529335
22  5888.0     905.846185    120.530390
23  6144.0     897.092006    120.543677
24  6400.0     903.529415    120.529670
25  6656.0     848.635336    120.504668
26  6912.0     896.086437    120.619604
27  7168.0     910.222229    120.607834
28  7424.0     906.748104    120.603093
29  7680.0     899.121934    120.638144
30  7936.0     851.235750    120.621834
31  8192.0     913.393751    120.679284
```
Input shape: (16, Seqlen, 2048)

```
    SeqLen  TritonRMSNorm  TorchRMSNorm
0    256.0     739.127852    140.434291
1    512.0     826.518105    119.084191
2    768.0     823.632734    119.379445
3   1024.0     860.428908    119.627620
4   1280.0     874.979929    120.058623
5   1536.0     873.813311    120.298596
6   1792.0     887.907071    120.428417
7   2048.0     894.689421    120.525975
8   2304.0     888.205570    120.565497
9   2560.0     894.307905    120.574023
10  2816.0     904.890362    120.591501
11  3072.0     901.182613    120.643071
12  3328.0     856.536221    120.459233
13  3584.0     906.027625    120.748041
14  3840.0     900.769696    120.697700
15  4096.0     910.749279    120.697370
16  4352.0     899.021163    114.230306
17  4608.0     909.995462    120.816057
18  4864.0     913.010053    120.758775
19  5120.0     911.910994    114.148116
20  5376.0     912.649195    120.809991
21  5632.0     913.960634    120.794405
22  5888.0     862.017814    120.792389
23  6144.0     916.048056    120.834617
24  6400.0     913.945709    120.878144
25  6656.0     862.634142    120.847236
26  6912.0     912.726265    120.898606
27  7168.0     914.152076    120.862363
28  7424.0     917.546213    120.912564
29  7680.0     862.946642    120.875486
30  7936.0     914.593039    120.858558
31  8192.0     864.923841    120.849801
```

</details>