### PR TITLE
Set initial layers independently from the of rest of the model

### DIFF
--- a/src/bert_layers/activation.py
+++ b/src/bert_layers/activation.py
@@ -52,8 +52,9 @@ def get_act_fn(config: Union[FlexBertConfig, str]) -> nn.Module:
     try:
         if isinstance(config, str):
             return ACT2FN[config]
-        return ACT2FN[config.activation_function]
+        return ACT2FN[config.hidden_act]
     except KeyError:
-        raise ValueError(
-            f"Invalid activation function type: {config.activation_function}, must be one of {ACT2FN.keys()}."
-        )
+        if isinstance(config, str):
+            raise ValueError(f"Invalid activation function type: {config}, must be one of {ACT2FN.keys()}.")
+        else:
+            raise ValueError(f"Invalid activation function type: {config.hidden_act=}, must be one of {ACT2FN.keys()}.")

--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -1285,15 +1285,15 @@ ATTN2CLS = {
 def get_attention_layer(config: FlexBertConfig, layer_id: Optional[int] = None) -> FlexBertAttentionBase:
     try:
         attention_layer = (
-            config.first_attention_layer
-            if layer_id == 0 and getattr(config, "first_attention_layer", None) is not None
+            config.initial_attention_layer
+            if layer_id < config.num_initial_layers and getattr(config, "initial_attention_layer", None) is not None
             else config.attention_layer
         )
         return ATTN2CLS[maybe_add_padding(config, attention_layer)](config, layer_id=layer_id)
     except KeyError:
-        if layer_id == 0 and getattr(config, "first_attention_layer", None) is not None:
+        if layer_id < config.num_initial_layers and getattr(config, "initial_attention_layer", None) is not None:
             raise ValueError(
-                f"Invalid attention layer type: {config.first_attention_layer=}, must be one of {ATTN2CLS.keys()}."
+                f"Invalid attention layer type: {config.initial_attention_layer=}, must be one of {ATTN2CLS.keys()}."
                 f"{config.padding=} will be automatically prepended to `config.attention_layer` if unspecified."
             )
         else:

--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -1284,9 +1284,20 @@ ATTN2CLS = {
 
 def get_attention_layer(config: FlexBertConfig, layer_id: Optional[int] = None) -> FlexBertAttentionBase:
     try:
-        return ATTN2CLS[maybe_add_padding(config, config.attention_layer)](config, layer_id=layer_id)
-    except KeyError:
-        raise ValueError(
-            f"Invalid attention layer type: {config.attention_layer=}, must be one of {ATTN2CLS.keys()}. "
-            f"{config.padding=} will be automatically prepended to `config.attention_layer` if unspecified."
+        attention_layer = (
+            config.first_attention_layer
+            if layer_id == 0 and getattr(config, "first_attention_layer", None) is not None
+            else config.attention_layer
         )
+        return ATTN2CLS[maybe_add_padding(config, attention_layer)](config, layer_id=layer_id)
+    except KeyError:
+        if layer_id == 0 and getattr(config, "first_attention_layer", None) is not None:
+            raise ValueError(
+                f"Invalid attention layer type: {config.first_attention_layer=}, must be one of {ATTN2CLS.keys()}."
+                f"{config.padding=} will be automatically prepended to `config.attention_layer` if unspecified."
+            )
+        else:
+            raise ValueError(
+                f"Invalid attention layer type: {config.attention_layer=}, must be one of {ATTN2CLS.keys()}. "
+                f"{config.padding=} will be automatically prepended to `config.attention_layer` if unspecified."
+            )

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -76,9 +76,10 @@ class FlexBertConfig(TransformersBertConfig):
         init_std: float = 0.02,
         init_cutoff_factor: float = 2.0,
         init_small_embedding: bool = False,
-        first_attention_layer: str | None = None,
-        first_bert_layer: str | None = None,
-        first_mlp_layer: str | None = None,
+        initial_attention_layer: str | None = None,
+        initial_bert_layer: str | None = None,
+        initial_mlp_layer: str | None = None,
+        num_initial_layers: int = 1,
         skip_first_prenorm: bool = False,
         **kwargs,
     ):
@@ -125,9 +126,10 @@ class FlexBertConfig(TransformersBertConfig):
             init_std (float): Standard deviation for initialization. Used for normal and full_megatron init.
             init_cutoff_factor (float): Cutoff factor for initialization. Used for normal and full_megatron init.
             init_small_embedding (bool): Initialize embeddings with RWKV small init.
-            first_attention_layer (str | None): Replace first attn_layer instance with this layer.
-            first_bert_layer (str | None): Replace first bert_layer instance with this layer.
-            first_mlp_layer (str | None): Replace first mlp_layer instance with this layer.
+            initial_attention_layer (str | None): Replace first `num_initial_layers` attention_layer instance with this layer.
+            initial_bert_layer (str | None): Replace first `num_initial_layers` bert_layer instance with this layer.
+            initial_mlp_layer (str | None): Replace first `num_initial_layers` mlp_layer instance with this layer.
+            num_initial_layers (int): Number of initial layers to set via `initial_attention_layer`, `initial_bert_layer`, and `initial_mlp_layer`.
             skip_first_prenorm (bool): Skip pre-normalization for the first bert layer. Requires `embed_norm=True`.
             **kwargs: Additional keyword arguments.
         """
@@ -172,9 +174,10 @@ class FlexBertConfig(TransformersBertConfig):
         self.init_std = init_std
         self.init_cutoff_factor = init_cutoff_factor
         self.init_small_embedding = init_small_embedding
-        self.first_attention_layer = first_attention_layer
-        self.first_bert_layer = first_bert_layer
-        self.first_mlp_layer = first_mlp_layer
+        self.initial_attention_layer = initial_attention_layer
+        self.initial_bert_layer = initial_bert_layer
+        self.initial_mlp_layer = initial_mlp_layer
+        self.num_initial_layers = num_initial_layers
         self.skip_first_prenorm = skip_first_prenorm
 
 

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -35,7 +35,6 @@ class BertConfig(TransformersBertConfig):
 class FlexBertConfig(TransformersBertConfig):
     def __init__(
         self,
-        activation_function: str = "silu",
         attention_layer: str = "base",
         attention_probs_dropout_prob: float = 0.0,
         attn_out_bias: bool = False,
@@ -77,10 +76,62 @@ class FlexBertConfig(TransformersBertConfig):
         init_std: float = 0.02,
         init_cutoff_factor: float = 2.0,
         init_small_embedding: bool = False,
+        first_attention_layer: str | None = None,
+        first_bert_layer: str | None = None,
+        first_mlp_layer: str | None = None,
+        skip_first_prenorm: bool = False,
         **kwargs,
     ):
+        """
+        Args:
+            attention_layer (str): Attention layer type.
+            attention_probs_dropout_prob (float): Dropout probability for attention probabilities.
+            attn_out_bias (bool): use bias in attention output projection.
+            attn_out_dropout_prob (float): Dropout probability for attention output.
+            attn_qkv_bias (bool): use bias for query, key, value linear layer(s).
+            bert_layer (str): BERT layer type.
+            decoder_bias (bool): use bias in decoder linear layer.
+            embed_dropout_prob (float): Dropout probability for embeddings.
+            embed_norm (bool): Normalize embedding output.
+            final_norm (bool): Add normalization after the final encoder layer and before head.
+            embedding_layer (str): Embedding layer type.
+            encoder_layer (str): Encoder layer type.
+            loss_function (str): Loss function to use.
+            loss_kwargs (dict): Keyword arguments for loss function.
+            mlp_dropout_prob (float): Dropout probability for MLP layers.
+            mlp_in_bias (bool): Use bias in MLP input linear layer.
+            mlp_layer (str): MLP layer type.
+            mlp_out_bias (bool): Use bias in MLP output linear layer.
+            norm_kwargs (dict): Keyword arguments for normalization layers.
+            normalization (str): Normalization type.
+            padding (str): Unpad inputs. Best with `use_fa2=True`.
+            head_class_act (str): Activation function for classification head.
+            head_class_bias (bool): Use bias in classification head linear layer(s).
+            head_class_dropout (float): Dropout probability for classification head.
+            head_class_norm (str): Normalization type for classification head.
+            head_pred_act (str): Activation function for prediction head.
+            head_pred_bias (bool): Use bias in prediction head linear layer(s).
+            head_pred_dropout (float): Dropout probability for prediction head.
+            head_pred_norm (bool): Normalize prediction head output.
+            pooling_type (str): Pooling type.
+            rotary_emb_dim (int | None): Rotary embedding dimension.
+            rotary_emb_base (float): Rotary embedding base.
+            rotary_emb_scale_base (float): Rotary embedding scale base.
+            rotary_emb_interleaved (bool): Use interleaved rotary embeddings.
+            use_fa2 (bool): Use FlashAttention2. Requires flash_attn package.
+            use_sdpa_attn_mask (bool): Pass a mask to SDPA. This will prevent SDPA from using the PyTorch FA2 kernel.
+            allow_embedding_resizing (bool): Embeddings will be automatically resized when they are smaller than the tokenizer vocab size.
+            init_method (str): Model layers initialization method.
+            init_std (float): Standard deviation for initialization. Used for normal and full_megatron init.
+            init_cutoff_factor (float): Cutoff factor for initialization. Used for normal and full_megatron init.
+            init_small_embedding (bool): Initialize embeddings with RWKV small init.
+            first_attention_layer (str | None): Replace first attn_layer instance with this layer.
+            first_bert_layer (str | None): Replace first bert_layer instance with this layer.
+            first_mlp_layer (str | None): Replace first mlp_layer instance with this layer.
+            skip_first_prenorm (bool): Skip pre-normalization for the first bert layer. Requires `embed_norm=True`.
+            **kwargs: Additional keyword arguments.
+        """
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
-        self.activation_function = activation_function
         self.attention_layer = attention_layer
         self.attn_out_bias = attn_out_bias
         self.attn_out_dropout_prob = attn_out_dropout_prob
@@ -121,6 +172,10 @@ class FlexBertConfig(TransformersBertConfig):
         self.init_std = init_std
         self.init_cutoff_factor = init_cutoff_factor
         self.init_small_embedding = init_small_embedding
+        self.first_attention_layer = first_attention_layer
+        self.first_bert_layer = first_bert_layer
+        self.first_mlp_layer = first_mlp_layer
+        self.skip_first_prenorm = skip_first_prenorm
 
 
 PADDING = ["unpadded", "padded"]

--- a/src/bert_layers/layers.py
+++ b/src/bert_layers/layers.py
@@ -526,15 +526,15 @@ LAYER2CLS = {
 def get_bert_layer(config: FlexBertConfig, layer_id: Optional[int] = None) -> FlexBertLayerBase:
     try:
         bert_layer = (
-            config.first_bert_layer
-            if layer_id == 0 and getattr(config, "first_bert_layer", None) is not None
+            config.initial_bert_layer
+            if layer_id < config.num_initial_layers and getattr(config, "initial_bert_layer", None) is not None
             else config.bert_layer
         )
         return LAYER2CLS[maybe_add_padding(config, bert_layer)](config, layer_id=layer_id)
     except KeyError:
-        if layer_id == 0 and getattr(config, "first_bert_layer", None) is not None:
+        if layer_id < config.num_initial_layers and getattr(config, "initial_bert_layer", None) is not None:
             raise ValueError(
-                f"Invalid BERT layer type: {config.first_bert_layer=}, must be one of {LAYER2CLS.keys()}."
+                f"Invalid BERT layer type: {config.initial_bert_layer=}, must be one of {LAYER2CLS.keys()}."
                 f"{config.padding=} will be automatically prepended to `config.bert_layer` if unspecified."
             )
         else:

--- a/src/bert_layers/mlp.py
+++ b/src/bert_layers/mlp.py
@@ -200,13 +200,15 @@ MLP2CLS = {
 def get_mlp_layer(config: FlexBertConfig, layer_id: Optional[int] = None) -> FlexBertMLPBase:
     try:
         mlp_layer = (
-            config.first_mlp_layer
-            if layer_id == 0 and getattr(config, "first_mlp_layer", None) is not None
+            config.initial_mlp_layer
+            if layer_id < config.num_initial_layers and getattr(config, "initial_mlp_layer", None) is not None
             else config.mlp_layer
         )
         return MLP2CLS[mlp_layer](config, layer_id=layer_id)
     except KeyError as e:
-        if layer_id == 0 and getattr(config, "first_mlp_layer", None) is not None:
-            raise ValueError(f"Invalid MLP layer type: {config.first_mlp_layer=}, must be one of {MLP2CLS.keys()}. {e}")
+        if layer_id < config.num_initial_layers and getattr(config, "initial_mlp_layer", None) is not None:
+            raise ValueError(
+                f"Invalid MLP layer type: {config.initial_mlp_layer=}, must be one of {MLP2CLS.keys()}. {e}"
+            )
         else:
             raise ValueError(f"Invalid MLP layer type: {config.mlp_layer=}, must be one of {MLP2CLS.keys()}. {e}")

--- a/src/bert_layers/mlp.py
+++ b/src/bert_layers/mlp.py
@@ -199,6 +199,14 @@ MLP2CLS = {
 
 def get_mlp_layer(config: FlexBertConfig, layer_id: Optional[int] = None) -> FlexBertMLPBase:
     try:
-        return MLP2CLS[config.mlp_layer](config, layer_id=layer_id)
-    except KeyError:
-        raise ValueError(f"Invalid MLP layer type: {config.mlp_layer=}, must be one of {MLP2CLS.keys()}.")
+        mlp_layer = (
+            config.first_mlp_layer
+            if layer_id == 0 and getattr(config, "first_mlp_layer", None) is not None
+            else config.mlp_layer
+        )
+        return MLP2CLS[mlp_layer](config, layer_id=layer_id)
+    except KeyError as e:
+        if layer_id == 0 and getattr(config, "first_mlp_layer", None) is not None:
+            raise ValueError(f"Invalid MLP layer type: {config.first_mlp_layer=}, must be one of {MLP2CLS.keys()}. {e}")
+        else:
+            raise ValueError(f"Invalid MLP layer type: {config.mlp_layer=}, must be one of {MLP2CLS.keys()}. {e}")

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -51,9 +51,11 @@ model:
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
-    first_attention_layer: null
-    first_bert_layer: null
-    first_mlp_layer: null
+    initial_attention_layer: null
+    initial_bert_layer: null
+    initial_mlp_layer: null
+    num_initial_layers: 1
+    skip_first_prenorm: false
 
 
 # Dataloaders

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -55,9 +55,10 @@ model:
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
-    first_attention_layer: rope
-    first_bert_layer: prenorm
-    first_mlp_layer: glu
+    initial_attention_layer: rope
+    initial_bert_layer: prenorm
+    initial_mlp_layer: glu
+    num_initial_layers: 1
     skip_first_prenorm: true
 
 # Dataloaders

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -6,12 +6,12 @@
 data_local: ./my-copy-c4
 data_remote: # If blank, files must be present in data_local
 
-max_seq_len: 128
+max_seq_len: 512
 tokenizer_name: bert-base-uncased # switch to bert tokenizer until we add [MASK] token to the llama tokenizer meta-llama/Llama-2-7b-hf
 mlm_probability: 0.3 # FlexBERT should use 30% masking for optimal performance
 
 # Run Name
-run_name: flex-bert-base-parallel
+run_name: flex-bert-rope-parallel-firstprenorm
 
 # Model
 model:
@@ -24,37 +24,41 @@ model:
   model_config:
     num_attention_heads: 12 # bert-base default
     num_hidden_layers: 12 # bert-base default
-    attention_layer: parallel
+    attention_layer: rope_parallel
     attention_probs_dropout_prob: 0.0
-    attn_out_bias: False
+    attn_out_bias: false
     attn_out_dropout_prob: 0.0
-    attn_qkv_bias: False
+    attn_qkv_bias: false
     bert_layer: parallel_prenorm
     embed_dropout_prob: 0.0
-    embed_norm: False
-    final_norm: True
-    embedding_layer: absolute_pos
+    embed_norm: true
+    final_norm: true
+    embedding_layer: sans_pos
     loss_function: cross_entropy
     loss_kwargs:
       reduction: mean
     mlp_dropout_prob: 0.0
-    mlp_in_bias: False
+    mlp_in_bias: false
     mlp_layer: parallel_glu
-    mlp_out_bias: False
+    mlp_out_bias: false
+    normalization: rmsnorm
     norm_kwargs:
       eps: 1e-6
-    normalization: rmsnorm
     padding: unpadded
-    sparse_prediction: False
+    sparse_prediction: false
+    rotary_emb_dim: null # will be set to headdim by default
+    rotary_emb_base: 10000.0
+    rotary_emb_scale_base: null
+    rotary_emb_interleaved: false
     hidden_act: silu
     init_method: default
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
-    first_attention_layer: null
-    first_bert_layer: null
-    first_mlp_layer: null
-
+    first_attention_layer: rope
+    first_bert_layer: prenorm
+    first_mlp_layer: glu
+    skip_first_prenorm: true
 
 # Dataloaders
 train_loader:
@@ -119,7 +123,7 @@ console_log_interval: 1ba
 
 callbacks:
   speed_monitor:
-    window_size: 500
+    window_size: 10
   lr_monitor: {}
 
 algorithms:


### PR DESCRIPTION
This PR allows setting the first BERT layer independent of the rest of the model layers. Eg, a PreNorm layer followed by Parallel Attention layers. `flex-bert-rope-parallel-firstprenorm.yaml` is an example of this feature. 

This PR also adds the ability to turn off duplicate PreNorm norms when `embed_norm=True` via `skip_first_prenorm`. The embedding norm additionally normalizes the residuals, which is why we would want to turn it on and have the first prenorm normalization layer turned off. 
