### PR TITLE
Fix eval flexbert

### DIFF
--- a/src/evals/glue_jobs.py
+++ b/src/evals/glue_jobs.py
@@ -14,8 +14,9 @@ from composer.core import Callback
 from composer.core.evaluator import Evaluator
 from composer.loggers import LoggerDestination
 from composer.optim import ComposerScheduler, DecoupledAdamW
+
 from src.evals.data import create_glue_dataset
-from src.evals.finetuning_jobs import build_dataloader, ClassificationJob
+from src.evals.finetuning_jobs import ClassificationJob, build_dataloader
 
 
 class MNLIJob(ClassificationJob):
@@ -77,17 +78,12 @@ class MNLIJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
         self.train_dataloader = build_dataloader(train_dataset, **dataloader_kwargs)
-        mnli_eval_dataset = create_glue_dataset(
-            split="validation_matched", **dataset_kwargs
-        )
-        mnli_eval_mismatched_dataset = create_glue_dataset(
-            split="validation_mismatched", **dataset_kwargs
-        )
+        mnli_eval_dataset = create_glue_dataset(split="validation_matched", **dataset_kwargs)
+        mnli_eval_mismatched_dataset = create_glue_dataset(split="validation_mismatched", **dataset_kwargs)
         mnli_evaluator = Evaluator(
             label="glue_mnli",
             dataloader=build_dataloader(mnli_eval_dataset, **dataloader_kwargs),
@@ -95,9 +91,7 @@ class MNLIJob(ClassificationJob):
         )
         mnli_evaluator_mismatched = Evaluator(
             label="glue_mnli_mismatched",
-            dataloader=build_dataloader(
-                mnli_eval_mismatched_dataset, **dataloader_kwargs
-            ),
+            dataloader=build_dataloader(mnli_eval_mismatched_dataset, **dataloader_kwargs),
             metric_names=["MulticlassAccuracy"],
         )
         self.evaluators = [mnli_evaluator, mnli_evaluator_mismatched]
@@ -162,7 +156,6 @@ class RTEJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -235,7 +228,6 @@ class QQPJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -308,7 +300,6 @@ class COLAJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -381,7 +372,6 @@ class MRPCJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -454,7 +444,6 @@ class QNLIJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -527,7 +516,6 @@ class SST2Job(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)
@@ -600,7 +588,6 @@ class STSBJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
         train_dataset = create_glue_dataset(split="train", **dataset_kwargs)

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -14,11 +14,12 @@ from composer.core import Callback
 from composer.core.evaluator import Evaluator
 from composer.loggers import LoggerDestination
 from composer.optim import ComposerScheduler, DecoupledAdamW
+
 from src.evals.data import create_swag_dataset
 from src.evals.finetuning_jobs import (
+    ClassificationJob,
     build_dataloader,
     multiple_choice_collate_fn,
-    ClassificationJob,
 )
 
 
@@ -79,8 +80,7 @@ class SWAGJob(ClassificationJob):
                 first_sentences = [[context] * 4 for context in inp["sent1"]]
                 question_headers = inp["sent2"]
                 second_sentences = [
-                    [f"{header} {inp[end][i]}" for end in ending_names]
-                    for i, header in enumerate(question_headers)
+                    [f"{header} {inp[end][i]}" for end in ending_names] for i, header in enumerate(question_headers)
                 ]
 
                 first_sentences = sum(first_sentences, [])
@@ -93,10 +93,7 @@ class SWAGJob(ClassificationJob):
                     max_length=max_seq_length,
                     truncation=True,
                 )
-                return {
-                    k: [v[i : i + 4] for i in range(0, len(v), 4)]
-                    for k, v in tokenized_examples.items()
-                }
+                return {k: [v[i : i + 4] for i in range(0, len(v), 4)] for k, v in tokenized_examples.items()}
 
             return tokenize_fn
 
@@ -110,7 +107,6 @@ class SWAGJob(ClassificationJob):
         dataloader_kwargs = {
             "batch_size": self.batch_size,
             "num_workers": 0,
-            "shuffle": True,
             "drop_last": False,
         }
 


### PR DESCRIPTION
**Changes**

When trying to launch the eval for arch ablations, they failed due to different issues.
First, `eval_metrics` parameter was not added to FlexBert models, only to MosaicBert.
Second, I had a `ValueError: sampler option is mutually exclusive with shuffle` so I removed the shuffle parameters from the different jobs.


**Tests**

- [ ] Is the new feature tested? (Not always necessary for all changes -- just adding to the checklist to keep track)
- [ ] Have you ran all the tests?
- [ ] Do the tests all pass?
- [ ] If not, have you included an explanation of which tests this PR breaks and/or why (below this checklist)

I did not runs the tests, but managed to run the evaluations with these fixes.
