### PR TITLE
Add ScheduledGarbageCollector callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import src.hf_bert as hf_bert_module
 import src.mosaic_bert as mosaic_bert_module
 import src.flex_bert as flex_bert_module
 import src.text_data as text_data_module
+from src.callbacks.scheduled_gc import ScheduledGarbageCollector
 from composer import Trainer, algorithms
 from composer.callbacks import LRMonitor, MemoryMonitor, OptimizerMonitor, RuntimeEstimator, SpeedMonitor
 from composer.loggers import WandBLogger
@@ -114,6 +115,8 @@ def build_callback(name, kwargs):
         return OptimizerMonitor(
             log_optimizer_metrics=kwargs.get("log_optimizer_metrics", True),
         )
+    elif name == "scheduled_gc":
+        return ScheduledGarbageCollector(batch_interval=kwargs.get("batch_interval", 10000))
     else:
         raise ValueError(f"Not sure how to build callback: {name}")
 

--- a/src/callbacks/scheduled_gc.py
+++ b/src/callbacks/scheduled_gc.py
@@ -1,0 +1,85 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+# from: https://github.com/mosaicml/llm-foundry/blob/main/llmfoundry/callbacks/scheduled_gc_callback.py
+
+import gc
+from typing import Optional
+
+import torch
+from composer.core import Callback, State
+from composer.loggers import Logger
+
+__all__ = ["ScheduledGarbageCollector"]
+
+
+def gc_cuda():
+    """Garbage collect Torch (CUDA) memory."""
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+class ScheduledGarbageCollector(Callback):
+    """Disable automatic garbage collection and collect garbage at interval.
+
+    Args:
+        batch_interval (int): Number of batches between calls to gc.collect()
+        gen_1_batch_interval(int, optional): Number of batches between calls to gc.collect(1)
+        eval_keep_disabled (bool): keep gc disabled during eval (default: False)
+    """
+
+    def __init__(
+        self,
+        batch_interval: int,
+        gen_1_batch_interval: Optional[int] = None,
+        eval_keep_disabled: bool = False,
+    ):
+        self.batch_interval = batch_interval
+        self.gen_1_batch_interval = gen_1_batch_interval
+        self.eval_keep_disabled = eval_keep_disabled
+        self.gc_init_state = None
+
+    def fit_start(self, state: State, logger: Logger) -> None:
+        del state, logger  # unused
+
+        # cache if automatic garbage collection is enabled; reset at fit_end
+        self.gc_init_state = gc.isenabled()
+
+        # disable automatic garbage collection
+        gc.disable()
+        gc_cuda()
+
+    def fit_end(self, state: State, logger: Logger) -> None:
+        del state, logger  # unused
+
+        gc_cuda()
+
+        # reset automatic garbage collection at fit_end
+        if self.gc_init_state:
+            gc.enable()
+        else:
+            gc.disable()
+
+    def before_dataloader(self, state: State, logger: Logger) -> None:
+        del logger  # unused
+
+        if self.gen_1_batch_interval is not None and state.timestamp.batch.value % self.gen_1_batch_interval == 0:
+            gc.collect(1)
+
+        if state.timestamp.batch.value % self.batch_interval == 0:
+            gc_cuda()
+
+    def eval_start(self, state: State, logger: Logger) -> None:
+        del state, logger  # unused
+
+        gc_cuda()
+        if not self.eval_keep_disabled:
+            gc.enable()
+
+    def eval_end(self, state: State, logger: Logger) -> None:
+        del state, logger  # unused
+
+        if not self.eval_keep_disabled:
+            gc.disable()
+
+        gc_cuda()


### PR DESCRIPTION
This PR adds the `ScheduledGarbageCollector` callback from LLM Foundry. The python garbage collector can [slowdown long training sessions](https://imbue.com/research/70b-infrastructure/):

> We noticed a pattern of periodic dips in throughput that almost appeared deterministic. As the training run progressed, the dips impacted a progressively larger percentage of distributed operations. This led to a hypothesis that the dips could be related to automatic garbage collection, which we validated by profiling and testing. Once we disabled automatic garbage collection and scheduled garbage collection to occur at specific intervals across all hosts, these throughput “sags” disappeared.

Mosaic [already noticed this](https://x.com/vitaliychiley/status/1805758299192836137) and used this callback to fix it. Unfortunately, they do not set defaults for `gc.collect()` or `gc.collect(1)`.