### PR TITLE
Fix eval global and device bs

### DIFF
--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -109,10 +109,12 @@ global_train_batch_size: 4096
 
 # System
 seed: 17
-device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
 precision: amp_bf16
+
+global_eval_batch_size: 256
+device_eval_batch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -103,10 +103,12 @@ global_train_batch_size: 4096
 
 # System
 seed: 17
-device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
 precision: amp_bf16
+
+global_eval_batch_size: 256
+device_eval_batch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -107,10 +107,12 @@ global_train_batch_size: 4096
 
 # System
 seed: 17
-device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
 precision: amp_bf16
+
+global_eval_batch_size: 256
+device_eval_batch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -112,10 +112,12 @@ global_train_batch_size: 4096
 
 # System
 seed: 17
-device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
 precision: amp_bf16
+
+global_eval_batch_size: 256
+device_eval_batch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/hf-bert-base-uncased.yaml
+++ b/yamls/main/hf-bert-base-uncased.yaml
@@ -77,10 +77,12 @@ global_train_batch_size: 4096
 
 # System
 seed: 17
-device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
 precision: amp_bf16
+
+global_eval_batch_size: 256
+device_eval_batch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/yamls/main/mosaic-bert-base-uncased.yaml
@@ -77,10 +77,12 @@ global_train_batch_size: 4096
 
 # System
 seed: 17
-device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
 precision: amp_bf16
+
+global_eval_batch_size: 256
+device_eval_batch_size: 64
 
 # Logging
 progress_bar: false


### PR DESCRIPTION
This PR fixes the default global and device eval batch sizes. The old variable of `device_eval_batch_size` was being ignored.