### PR TITLE
Add support for device_eval_microbatch_size

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import src.mosaic_bert as mosaic_bert_module
 import src.flex_bert as flex_bert_module
 import src.text_data as text_data_module
 from src.callbacks.scheduled_gc import ScheduledGarbageCollector
-from composer import Trainer, algorithms
+from composer import Trainer, algorithms, Evaluator
 from composer.callbacks import LRMonitor, MemoryMonitor, OptimizerMonitor, RuntimeEstimator, SpeedMonitor
 from composer.loggers import WandBLogger
 from composer.optim import DecoupledAdamW
@@ -51,12 +51,25 @@ def update_batch_size_info(cfg: DictConfig):
     cfg.n_gpus = dist.get_world_size()
     cfg.device_train_batch_size = device_train_batch_size
     cfg.device_train_microbatch_size = device_microbatch_size
-    # Safely set `device_eval_batch_size` if not provided by user
-    if "device_eval_batch_size" not in cfg:
+
+    # Safely set `device_eval_microbatch_size` if not provided by user
+    if "device_eval_microbatch_size" not in cfg:
         if cfg.device_train_microbatch_size == "auto":
-            cfg.device_eval_batch_size = 1
+            cfg.device_eval_microbatch_size = 1
         else:
-            cfg.device_eval_batch_size = cfg.device_train_microbatch_size
+            cfg.device_eval_microbatch_size = cfg.device_train_microbatch_size
+
+    global_eval_batch_size, device_eval_microbatch_size = cfg.global_eval_batch_size, cfg.device_eval_microbatch_size
+    device_eval_batch_size = global_eval_batch_size // dist.get_world_size()
+    if isinstance(device_eval_microbatch_size, int):
+        if device_eval_microbatch_size > device_eval_microbatch_size:
+            print(
+                f"WARNING: device_eval_microbatch_size > device_eval_batch_size, "
+                f"will be reduced from {device_eval_microbatch_size} -> {device_eval_batch_size}."
+            )
+            device_eval_microbatch_size = device_eval_batch_size
+    cfg.device_eval_batch_size = device_eval_batch_size
+    cfg.device_eval_microbatch_size = device_eval_microbatch_size
     return cfg
 
 
@@ -258,7 +271,12 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
     eval_loader = build_dataloader(
         cfg.eval_loader,
         model.tokenizer,
-        global_eval_batch_size // dist.get_world_size(),
+        cfg.get("device_eval_batch_size", global_eval_batch_size // dist.get_world_size()),
+    )
+    eval_evaluator = Evaluator(
+        label="eval",
+        dataloader=eval_loader,
+        device_eval_microbatch_size=cfg.get("device_eval_microbatch_size", None),
     )
 
     # Optimizer
@@ -294,7 +312,7 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
         model=model,
         algorithms=algorithms,
         train_dataloader=train_loader,
-        eval_dataloader=eval_loader,
+        eval_dataloader=eval_evaluator,
         train_subset_num_batches=cfg.get("train_subset_num_batches", -1),
         eval_subset_num_batches=cfg.get("eval_subset_num_batches", -1),
         optimizers=optimizer,

--- a/sequence_classification.py
+++ b/sequence_classification.py
@@ -15,7 +15,7 @@ import src.hf_bert as hf_bert_module
 import src.mosaic_bert as mosaic_bert_module
 import src.flex_bert as flex_bert_module
 import transformers
-from composer import Trainer, algorithms
+from composer import Trainer, algorithms, Evaluator
 from composer.callbacks import LRMonitor, MemoryMonitor, OptimizerMonitor, RuntimeEstimator, SpeedMonitor
 from composer.core.types import Dataset
 from composer.loggers import WandBLogger
@@ -51,12 +51,25 @@ def update_batch_size_info(cfg: DictConfig):
     cfg.n_gpus = dist.get_world_size()
     cfg.device_train_batch_size = device_train_batch_size
     cfg.device_train_microbatch_size = device_microbatch_size
-    # Safely set `device_eval_batch_size` if not provided by user
-    if "device_eval_batch_size" not in cfg:
+
+    # Safely set `device_eval_microbatch_size` if not provided by user
+    if "device_eval_microbatch_size" not in cfg:
         if cfg.device_train_microbatch_size == "auto":
-            cfg.device_eval_batch_size = 1
+            cfg.device_eval_microbatch_size = 1
         else:
-            cfg.device_eval_batch_size = cfg.device_train_microbatch_size
+            cfg.device_eval_microbatch_size = cfg.device_train_microbatch_size
+
+    global_eval_batch_size, device_eval_microbatch_size = cfg.global_eval_batch_size, cfg.device_eval_microbatch_size
+    device_eval_batch_size = global_eval_batch_size // dist.get_world_size()
+    if isinstance(device_eval_microbatch_size, int):
+        if device_eval_microbatch_size > device_eval_microbatch_size:
+            print(
+                f"WARNING: device_eval_microbatch_size > device_eval_batch_size, "
+                f"will be reduced from {device_eval_microbatch_size} -> {device_eval_batch_size}."
+            )
+            device_eval_microbatch_size = device_eval_batch_size
+    cfg.device_eval_batch_size = device_eval_batch_size
+    cfg.device_eval_microbatch_size = device_eval_microbatch_size
     return cfg
 
 
@@ -248,7 +261,12 @@ def train(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) 
     global_eval_batch_size = cfg.get("global_eval_batch_size", cfg.global_train_batch_size)
     eval_loader = build_my_dataloader(
         cfg.eval_loader,
-        global_eval_batch_size // dist.get_world_size(),
+        cfg.get("device_eval_batch_size", global_eval_batch_size // dist.get_world_size()),
+    )
+    eval_evaluator = Evaluator(
+        label="eval",
+        dataloader=eval_loader,
+        device_eval_microbatch_size=cfg.get("device_eval_microbatch_size", None),
     )
 
     # Optimizer
@@ -276,7 +294,7 @@ def train(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) 
         model=model,
         algorithms=algorithms,
         train_dataloader=train_loader,
-        eval_dataloader=eval_loader,
+        eval_dataloader=eval_evaluator,
         train_subset_num_batches=cfg.get("train_subset_num_batches", -1),
         eval_subset_num_batches=cfg.get("eval_subset_num_batches", -1),
         optimizers=optimizer,

--- a/tests/smoketest_config_classification.yaml
+++ b/tests/smoketest_config_classification.yaml
@@ -51,7 +51,7 @@ global_train_batch_size: 4
 
 # System
 seed: 17
-device_eval_batch_size: 4
+device_eval_microbatch_size: 4
 device_train_microbatch_size: 2
 precision: fp32
 

--- a/tests/smoketest_config_main.yaml
+++ b/tests/smoketest_config_main.yaml
@@ -65,7 +65,7 @@ global_train_batch_size: 4
 
 # System
 seed: 17
-device_eval_batch_size: 4
+device_eval_microbatch_size: 4
 device_train_microbatch_size: 2
 precision: fp32
 

--- a/tests/smoketest_config_sdpa_fa2.yaml
+++ b/tests/smoketest_config_sdpa_fa2.yaml
@@ -65,7 +65,7 @@ global_train_batch_size: 4
 
 # System
 seed: 17
-device_eval_batch_size: 4
+device_eval_microbatch_size: 4
 device_train_microbatch_size: 2
 precision: amp_bf16
 

--- a/yamls/finetuning/hf-bert-base-uncased.yaml
+++ b/yamls/finetuning/hf-bert-base-uncased.yaml
@@ -62,7 +62,7 @@ global_train_batch_size: 16
 
 # System
 seed: 17
-device_eval_batch_size: 16
+device_eval_microbatch_size: 16
 device_train_microbatch_size: 16
 precision: amp_bf16
 

--- a/yamls/finetuning/mosaic-bert-base-uncased.yaml
+++ b/yamls/finetuning/mosaic-bert-base-uncased.yaml
@@ -61,7 +61,7 @@ global_train_batch_size: 16
 
 # System
 seed: 17
-device_eval_batch_size: 16
+device_eval_microbatch_size: 16
 device_train_microbatch_size: 16
 precision: amp_bf16
 

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -114,7 +114,7 @@ device_train_microbatch_size: 128
 precision: amp_bf16
 
 global_eval_batch_size: 256
-device_eval_batch_size: 64
+device_eval_microbatch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -108,7 +108,7 @@ device_train_microbatch_size: 128
 precision: amp_bf16
 
 global_eval_batch_size: 256
-device_eval_batch_size: 64
+device_eval_microbatch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -112,7 +112,7 @@ device_train_microbatch_size: 128
 precision: amp_bf16
 
 global_eval_batch_size: 256
-device_eval_batch_size: 64
+device_eval_microbatch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -117,7 +117,7 @@ device_train_microbatch_size: 128
 precision: amp_bf16
 
 global_eval_batch_size: 256
-device_eval_batch_size: 64
+device_eval_microbatch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/hf-bert-base-uncased.yaml
+++ b/yamls/main/hf-bert-base-uncased.yaml
@@ -82,7 +82,7 @@ device_train_microbatch_size: 128
 precision: amp_bf16
 
 global_eval_batch_size: 256
-device_eval_batch_size: 64
+device_eval_microbatch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/yamls/main/mosaic-bert-base-uncased.yaml
@@ -82,7 +82,7 @@ device_train_microbatch_size: 128
 precision: amp_bf16
 
 global_eval_batch_size: 256
-device_eval_batch_size: 64
+device_eval_microbatch_size: 64
 
 # Logging
 progress_bar: false

--- a/yamls/test/main.yaml
+++ b/yamls/test/main.yaml
@@ -68,10 +68,11 @@ max_duration: 10ba
 eval_interval: 10ba
 eval_subset_num_batches: 20 # For code testing, evaluate on a subset of 20 batches
 global_train_batch_size: 16
+global_eval_batch_size: 16
 
 # System
 seed: 17
-device_eval_batch_size: 16
+device_eval_microbatch_size: 16
 device_train_microbatch_size: 16
 precision: fp32
 

--- a/yamls/test/sequence_classification.yaml
+++ b/yamls/test/sequence_classification.yaml
@@ -58,7 +58,7 @@ global_train_batch_size: 16
 
 # System
 seed: 17
-device_eval_batch_size: 16
+device_eval_microbatch_size: 16
 device_train_microbatch_size: 16
 precision: fp32
 


### PR DESCRIPTION
This PR enables setting the `device_eval_microbatch_size` via config or cli arg by wrapping the eval dataloader in a Composer [Evaluator](https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Evaluator.html).

I also removed the `device_eval_batch_size` config option since it didn't do anything.