### PR TITLE
Add support for FA2 deterministic mode

### DIFF
--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -11,6 +11,7 @@ class BertConfig(TransformersBertConfig):
         normalization: str = "layernorm",
         attention_probs_dropout_prob: float = 0.0,
         head_pred_act: str = "gelu",
+        deterministic_fa2: bool = False,
         **kwargs,
     ):
         """Configuration class for MosaicBert.
@@ -30,6 +31,7 @@ class BertConfig(TransformersBertConfig):
         self.alibi_starting_size = alibi_starting_size
         self.normalization = normalization
         self.head_pred_act = head_pred_act
+        self.deterministic_fa2 = deterministic_fa2
 
 
 class FlexBertConfig(TransformersBertConfig):
@@ -81,6 +83,7 @@ class FlexBertConfig(TransformersBertConfig):
         initial_mlp_layer: str | None = None,
         num_initial_layers: int = 1,
         skip_first_prenorm: bool = False,
+        deterministic_fa2: bool = False,
         **kwargs,
     ):
         """
@@ -131,6 +134,7 @@ class FlexBertConfig(TransformersBertConfig):
             initial_mlp_layer (str | None): Replace first `num_initial_layers` mlp_layer instance with this layer.
             num_initial_layers (int): Number of initial layers to set via `initial_attention_layer`, `initial_bert_layer`, and `initial_mlp_layer`.
             skip_first_prenorm (bool): Skip pre-normalization for the first bert layer. Requires `embed_norm=True`.
+            deterministic_fa2 (bool): Use Flash Attention 2 deterministic mode. This is slower then the default non-deterministic mode.
             **kwargs: Additional keyword arguments.
         """
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
@@ -179,6 +183,7 @@ class FlexBertConfig(TransformersBertConfig):
         self.initial_mlp_layer = initial_mlp_layer
         self.num_initial_layers = num_initial_layers
         self.skip_first_prenorm = skip_first_prenorm
+        self.deterministic_fa2 = deterministic_fa2
 
 
 PADDING = ["unpadded", "padded"]

--- a/tests/smoketest_config_ablation_eval.yaml
+++ b/tests/smoketest_config_ablation_eval.yaml
@@ -13,6 +13,8 @@ tokenizer_name: bert-base-uncased
 model:
   pretrained_model_name: prajjwal1/bert-tiny
   tokenizer_name: ${tokenizer_name}
+  model_config:
+    deterministic_fa2: true
 
 # Loading
 starting_checkpoint_load_path:      # Start from scratch for the sake of testing

--- a/tests/smoketest_config_glue.yaml
+++ b/tests/smoketest_config_glue.yaml
@@ -13,6 +13,8 @@ tokenizer_name: bert-base-uncased
 model:
   pretrained_model_name: prajjwal1/bert-tiny
   tokenizer_name: ${tokenizer_name}
+  model_config:
+    deterministic_fa2: true
 
 # Loading
 starting_checkpoint_load_path:      # Start from scratch for the sake of testing

--- a/tests/smoketest_config_superglue.yaml
+++ b/tests/smoketest_config_superglue.yaml
@@ -13,6 +13,8 @@ tokenizer_name: bert-base-uncased
 model:
   pretrained_model_name: prajjwal1/bert-tiny
   tokenizer_name: ${tokenizer_name}
+  model_config:
+    deterministic_fa2: true
 
 # Loading
 starting_checkpoint_load_path:      # Start from scratch for the sake of testing

--- a/yamls/ablations/flex-bert-ablation-eval.yaml
+++ b/yamls/ablations/flex-bert-ablation-eval.yaml
@@ -50,6 +50,7 @@ model:
     rotary_emb_interleaved: false
     head_class_norm: None
     head_class_act: "tanh"
+    deterministic_fa2: true
 
 # Loading
 # # (fill this in with the composer checkpoint from the end of pre-training a Mosaic BERT)

--- a/yamls/ablations/mosaic-bert-ablation-eval.yaml
+++ b/yamls/ablations/mosaic-bert-ablation-eval.yaml
@@ -15,6 +15,8 @@ model:
   use_pretrained: true
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
+  model_config:
+    deterministic_fa2: true
 
 # Saving
 save_finetune_checkpoint_prefix: ./bert-finetune-checkpoints

--- a/yamls/finetuning/glue/mosaic-bert-base-uncased.yaml
+++ b/yamls/finetuning/glue/mosaic-bert-base-uncased.yaml
@@ -17,6 +17,8 @@ model:
   name: mosaic_bert
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
+  model_config:
+    deterministic_fa2: true
 
 # Loading
 # (fill this in with the composer checkpoint from the end of pre-training a Mosaic BERT)

--- a/yamls/finetuning/mosaic-bert-base-uncased.yaml
+++ b/yamls/finetuning/mosaic-bert-base-uncased.yaml
@@ -21,6 +21,8 @@ model:
   num_labels: 2 # <-- Make sure to update these after you modify the starter script!
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
+  model_config:
+    deterministic_fa2: true
 
 # Dataloaders (make sure to update these after you modify the starter script!)
 train_loader:

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -56,6 +56,7 @@ model:
     initial_mlp_layer: null
     num_initial_layers: 1
     skip_first_prenorm: false
+    deterministic_fa2: false
 
 
 # Dataloaders

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -51,6 +51,7 @@ model:
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
+    deterministic_fa2: false
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -55,6 +55,7 @@ model:
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
+    deterministic_fa2: false
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -60,6 +60,7 @@ model:
     initial_mlp_layer: glu
     num_initial_layers: 1
     skip_first_prenorm: true
+    deterministic_fa2: false
 
 # Dataloaders
 train_loader:

--- a/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/yamls/main/mosaic-bert-base-uncased.yaml
@@ -25,6 +25,7 @@ model:
     num_attention_heads: 12 # bert-base default
     num_hidden_layers: 12 # bert-base default
     attention_probs_dropout_prob: 0.0 # This can be non zero with Flash Attention 2
+    deterministic_fa2: false
 
 # Dataloaders
 train_loader:


### PR DESCRIPTION
**Changes**

This PR adds a config option to enable Flash Attention 2's deterministic mode. Determinism will slow down FA2, so I have disabled it by default for pretraining configs but enabled it for all evaluation configs. 

**Tests**

- [x] Is the new feature tested? (Not always necessary for all changes -- just adding to the checklist to keep track)
- [x] Have you ran all the tests?
- [x] Do the tests all pass?
