### PR TITLE
Add support for loading pre-tokenized data

### DIFF
--- a/src/text_data.py
+++ b/src/text_data.py
@@ -157,9 +157,6 @@ class StreamingTextDataset(StreamingDataset):
         return self.tokenizer(text_sample["text"], truncation=True, padding="max_length", max_length=self.max_seq_len)
 
     def _read_binary_tokenized_sample(self, sample: BatchEncoding):
-        pad_token_id = self.tokenizer.pad_token_id
-        # print('pad token id : ', pad_token_id)
-
         seq_len = sample['len'] if 'len' in sample else len(sample['input_ids'])
         
         input_ids = np.frombuffer(sample["input_ids"], dtype=np.int64)[: self.max_seq_len].copy()
@@ -170,7 +167,7 @@ class StreamingTextDataset(StreamingDataset):
 
         # pad or truncate input_ids and attention_mask
         if pad_len > 0:
-            input_ids = np.pad(input_ids, (0, pad_len), constant_values=pad_token_id)
+            input_ids = np.pad(input_ids, (0, pad_len), constant_values=self.tokenizer.pad_token_id)
             attention_mask = np.pad(attention_mask, (0, pad_len), constant_values=0)
         elif pad_len < 0:
             input_ids = input_ids[:self.max_seq_len]
@@ -185,7 +182,6 @@ class StreamingTextDataset(StreamingDataset):
                 "token_type_ids": token_type_ids.tolist()
                 },
             n_sequences=1,
-            
             )
 
     # How to process a sample

--- a/src/text_data.py
+++ b/src/text_data.py
@@ -16,6 +16,8 @@ from streaming import Stream, StreamingDataset
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 
+from transformers.tokenization_utils_base import BatchEncoding
+    
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 
 
@@ -154,18 +156,47 @@ class StreamingTextDataset(StreamingDataset):
 
         return self.tokenizer(text_sample["text"], truncation=True, padding="max_length", max_length=self.max_seq_len)
 
-    def _read_binary_tokenized_sample(self, sample):
-        return torch.from_numpy(np.frombuffer(sample["tokens"], dtype=np.int64)[: self.max_seq_len].copy())
+    def _read_binary_tokenized_sample(self, sample: BatchEncoding):
+        pad_token_id = self.tokenizer.pad_token_id
+        # print('pad token id : ', pad_token_id)
+
+        seq_len = sample['len'] if 'len' in sample else len(sample['input_ids'])
+        
+        input_ids = np.frombuffer(sample["input_ids"], dtype=np.int64)[: self.max_seq_len].copy()
+        attention_mask = np.frombuffer(sample["attention_mask"], dtype=np.int64)[: self.max_seq_len].copy()
+
+        # calculate padding
+        pad_len = self.max_seq_len - seq_len
+
+        # pad or truncate input_ids and attention_mask
+        if pad_len > 0:
+            input_ids = np.pad(input_ids, (0, pad_len), constant_values=pad_token_id)
+            attention_mask = np.pad(attention_mask, (0, pad_len), constant_values=0)
+        elif pad_len < 0:
+            input_ids = input_ids[:self.max_seq_len]
+            attention_mask = attention_mask[:self.max_seq_len]
+
+        token_type_ids = np.zeros(self.max_seq_len, dtype=np.int64)
+
+        return BatchEncoding(
+            data={
+                "input_ids": input_ids.tolist(),
+                "attention_mask": attention_mask.tolist(),
+                "token_type_ids": token_type_ids.tolist()
+                },
+            n_sequences=1,
+            
+            )
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Union[Dict[str, Any], torch.Tensor]:
         sample = super().__getitem__(idx)
         if "text" in sample:
             token_sample = self._tokenize(sample)
-        elif "tokens" in sample:
+        elif "input_ids" in sample:
             token_sample = self._read_binary_tokenized_sample(sample)
         else:
-            raise RuntimeError("StreamingTextDataset needs samples to have a `text` or `tokens` column")
+            raise RuntimeError("StreamingTextDataset needs samples to have a `text` or `input_ids` column")
         return token_sample
 
 
@@ -322,6 +353,7 @@ if __name__ == "__main__":
         },
         "drop_last": False,
         "num_workers": 4,
+        "pin_memory": True
     }
     cfg = om.create(cfg)
     device_batch_size = 2

--- a/src/text_data.py
+++ b/src/text_data.py
@@ -159,8 +159,8 @@ class StreamingTextDataset(StreamingDataset):
     def _read_binary_tokenized_sample(self, sample: BatchEncoding):
         seq_len = sample["len"] if "len" in sample else len(sample["input_ids"])
 
-        input_ids = np.frombuffer(sample["input_ids"], dtype=np.int64)[: self.max_seq_len].copy()
-        attention_mask = np.frombuffer(sample["attention_mask"], dtype=np.int64)[: self.max_seq_len].copy()
+        input_ids = np.frombuffer(sample["input_ids"], dtype=np.int64).copy()
+        attention_mask = np.frombuffer(sample["attention_mask"], dtype=np.int64).copy()
 
         # calculate padding
         pad_len = self.max_seq_len - seq_len

--- a/src/text_data.py
+++ b/src/text_data.py
@@ -17,7 +17,7 @@ from torch.utils.data import DataLoader
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from transformers.tokenization_utils_base import BatchEncoding
-    
+
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 
 
@@ -157,8 +157,8 @@ class StreamingTextDataset(StreamingDataset):
         return self.tokenizer(text_sample["text"], truncation=True, padding="max_length", max_length=self.max_seq_len)
 
     def _read_binary_tokenized_sample(self, sample: BatchEncoding):
-        seq_len = sample['len'] if 'len' in sample else len(sample['input_ids'])
-        
+        seq_len = sample["len"] if "len" in sample else len(sample["input_ids"])
+
         input_ids = np.frombuffer(sample["input_ids"], dtype=np.int64)[: self.max_seq_len].copy()
         attention_mask = np.frombuffer(sample["attention_mask"], dtype=np.int64)[: self.max_seq_len].copy()
 
@@ -170,8 +170,8 @@ class StreamingTextDataset(StreamingDataset):
             input_ids = np.pad(input_ids, (0, pad_len), constant_values=self.tokenizer.pad_token_id)
             attention_mask = np.pad(attention_mask, (0, pad_len), constant_values=0)
         elif pad_len < 0:
-            input_ids = input_ids[:self.max_seq_len]
-            attention_mask = attention_mask[:self.max_seq_len]
+            input_ids = input_ids[: self.max_seq_len]
+            attention_mask = attention_mask[: self.max_seq_len]
 
         token_type_ids = np.zeros(self.max_seq_len, dtype=np.int64)
 
@@ -179,10 +179,10 @@ class StreamingTextDataset(StreamingDataset):
             data={
                 "input_ids": input_ids.tolist(),
                 "attention_mask": attention_mask.tolist(),
-                "token_type_ids": token_type_ids.tolist()
-                },
+                "token_type_ids": token_type_ids.tolist(),
+            },
             n_sequences=1,
-            )
+        )
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Union[Dict[str, Any], torch.Tensor]:
@@ -349,7 +349,7 @@ if __name__ == "__main__":
         },
         "drop_last": False,
         "num_workers": 4,
-        "pin_memory": True
+        "pin_memory": True,
     }
     cfg = om.create(cfg)
     device_batch_size = 2


### PR DESCRIPTION
**Changes**

Modify the **_read_binary_tokenized_sample** method of **StreamingTextDataset** to load pre-tokenized MDS files. It handles truncation and padding. 

The output is adapted to mirror the output of a tokenizer, i.e it returns a **BatchEncoding**.


It works for FlexBert but there is an issue with MosaicBert, something with the _token_type_embeddings_. Will update when the issue is fixed.

EDIT : the issue was data tokenized in a different tokenizer 
