### PR TITLE
Fix initialization

### DIFF
--- a/src/bert_layers/layers.py
+++ b/src/bert_layers/layers.py
@@ -337,7 +337,7 @@ class FlexBertUnpadParallelPreNormLayer(FlexBertLayerBase):
 
     def _init_weights(self, reset_params: bool = False):
         super()._init_weights(reset_params)
-        if reset_params:
+        if reset_params and hasattr(self.norm, "reset_parameters"):
             self.norm.reset_parameters()
 
         init_weights(

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -708,6 +708,7 @@ class FlexBertPredictionHead(nn.Module):
 class FlexBertPoolingHead(nn.Module):
     def __init__(self, config: FlexBertConfig):
         super().__init__()
+        self.config = config
         self.dense = nn.Linear(config.hidden_size, config.hidden_size, config.head_class_bias)
         self.act = get_act_fn(config.head_class_act) if config.head_class_act else nn.Identity()
         self.norm = get_norm_layer(config) if config.head_class_norm else nn.Identity()


### PR DESCRIPTION
This PR fixes `FlexBert` so the different weight initialization methods are not replaced by the Hugging Face `BertPreTrainedModel` weight initialization settings.

By default, all models are still initialized by the Hugging Face Bert method so there is no change relative to existing ablation runs.

I double checked that all the init values look sane using the following script:

<details>

```python
import typer
from typing import Optional
from pathlib import Path
import json

from src.bert_layers.configuration_bert import FlexBertConfig
from src.bert_layers.model import FlexBertForMaskedLM
from src.bert_layers.initialization import InitFnType

app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]}, pretty_exceptions_show_locals=False)


def get_model(
    hidden_size: int,
    num_hidden_layers: int,
    intermediate_size: float,
    parallel_attn: bool = True,
    vocab_size: int = 32768,
    init_method: InitFnType = "default",
    init_small_embedding: bool = False,
):
    config = FlexBertConfig(
        num_attention_heads=hidden_size // 64,
        hidden_size=hidden_size,
        num_hidden_layers=num_hidden_layers,
        intermediate_size=intermediate_size,
        vocab_size=vocab_size,
        attention_layer="rope_parallel" if parallel_attn else "rope",
        attention_probs_dropout_prob=0.0,
        attn_out_bias=False,
        attn_out_dropout_prob=0.0,
        attn_qkv_bias=False,
        bert_layer="parallel_prenorm" if parallel_attn else "prenorm",
        decoder_bias=False,
        embed_dropout_prob=0.0,
        embed_norm=True,
        final_norm=False,
        embedding_layer="sans_pos",
        encoder_layer="base",
        loss_function="cross_entropy",
        loss_kwargs={"reduction": "mean"},
        mlp_dropout_prob=0.0,
        mlp_in_bias=False,
        mlp_layer="parallel_glu" if parallel_attn else "glu",
        mlp_out_bias=False,
        norm_kwargs={"eps": 1e-5},
        normalization="layernorm",
        padding="padded",
        head_class_act="silu",
        head_class_bias=False,
        head_class_dropout=0.0,
        head_class_norm=False,
        head_pred_act="silu",
        head_pred_bias=False,
        head_pred_dropout=0.0,
        head_pred_norm=True,
        pooling_type="cls",
        rotary_emb_dim=None,
        rotary_emb_base=10000.0,
        rotary_emb_scale_base=None,
        rotary_emb_interleaved=False,
        use_fa2=True,
        use_sdpa_attn_mask=False,
        allow_embedding_resizing=False,
        init_method=InitFnType(init_method).value,
        init_std=0.02,
        init_cutoff_factor=2.0,
        init_small_embedding=init_small_embedding,
        initial_attention_layer=None,
        initial_bert_layer=None,
        initial_mlp_layer=None,
        num_initial_layers=1,
        skip_first_prenorm=False,
    )
    config.tie_word_embeddings = True
    return FlexBertForMaskedLM(config)


def analyze_model(model):
    results = []
    for name, param in model.named_parameters():
        if "weight" in name:
            result = {
                "Layer": name,
                "Shape": str(param.shape),
                "Mean": param.data.mean().item(),
                "Std": param.data.std().item(),
                "Min": param.data.min().item(),
                "Max": param.data.max().item(),
            }
            results.append(result)
    return results


@app.command()
def show_init(
    init_method: InitFnType = typer.Option("default", help="Initialization method"),
    init_small_embedding: bool = typer.Option(False, help="Initialize small embedding"),
    output_file: Optional[Path] = typer.Option(None, help="Output file path for results"),
    hidden_size: int = typer.Option(768, help="Hidden size of the model"),
    num_hidden_layers: int = typer.Option(22, help="Number of hidden layers"),
    intermediate_size: int = typer.Option(1408, help="Intermediate size"),
    parallel_attn: bool = typer.Option(True, help="Use parallel attention"),
    vocab_size: int = typer.Option(32768, help="Vocabulary size"),
):
    model = get_model(
        hidden_size, num_hidden_layers, intermediate_size, parallel_attn, vocab_size, init_method, init_small_embedding
    )
    results = analyze_model(model)

    if output_file:
        with output_file.open("w") as f:
            json.dump(results, f, indent=2)
        typer.echo(f"Results saved to {output_file}")
    else:
        for result in results:
            typer.echo(f"Layer: {result['Layer']}")
            typer.echo(f"Shape: {result['Shape']}")
            typer.echo(f"Mean: {result['Mean']}")
            typer.echo(f"Std: {result['Std']}")
            typer.echo(f"Min: {result['Min']}")
            typer.echo(f"Max: {result['Max']}")
            typer.echo("---")


if __name__ == "__main__":
    app()

```

</details>
