### PR TITLE
Add dataset without streaming

### DIFF
--- a/src/data/mds_conversion.py
+++ b/src/data/mds_conversion.py
@@ -1,0 +1,97 @@
+"""
+This script allows conversion of mds-data, such as
+* Compressing or decompressing a dataset
+* Removing unnecessary fields
+* Adapting `input_ids` to a more appropriate dtype
+"""
+
+import argparse
+import os, json
+import pandas as pd
+import numpy as np
+from streaming.base.format.mds.writer import MDSWriter
+from streaming.base.format import reader_from_json
+from streaming.base.compression import decompress
+from tqdm import tqdm
+import numpy as np
+
+def maybe_decompress_shard(shard, keep_zip: bool = True):
+    """
+    If shard does not have decompressed data,
+    this function decompresses the shard
+    """
+    raw_filename = os.path.join(shard.dirname, shard.split, shard.raw_data.basename)
+    if not os.path.isfile(raw_filename):
+        zip_filename = os.path.join(shard.dirname, shard.split, shard.zip_data.basename)
+        data = open(zip_filename, 'rb').read()
+        data = decompress(shard.compression, data)
+        tmp_filename = raw_filename + '.tmp'
+        with open(tmp_filename, 'wb') as out:
+            out.write(data)
+        os.rename(tmp_filename, raw_filename)
+
+        # Maybe remove compressed to save space.
+        if not keep_zip:
+            os.remove(zip_filename)
+
+def main():
+    # Initialize the argument parser
+    parser = argparse.ArgumentParser()
+    
+    # Define the arguments
+    parser.add_argument('--data_path', type=str, required=True, help='Path to the data file')
+    parser.add_argument('--read_split', type=str, required=True, help='Data split to read data from')
+    parser.add_argument('--write_split', type=str, default=None, help='Data split to write data to')
+    parser.add_argument('--dtype', type=str, default=None, help='Data type to convert the values of input_ids to')
+    parser.add_argument('--columns_to_keep', type=str, nargs='+', default=None, help='List of columns to keep, if None, all columns will be kept')
+    parser.add_argument('--decompress', action='store_true', help='If data in read_split should be be decompressed. Necessary if there is only compressed data in read_split')
+    parser.add_argument('--keep_zip', type=bool, default=True, help='Whether the compressed files should be kept after decompression or not')
+    parser.add_argument('--compression', type=str, default=None, help='Compression type to use for the data to write')
+    
+    # Parse the arguments
+    args = parser.parse_args()
+    print(args.columns_to_keep)
+    
+    # Verify that the data path exists
+    if not os.path.exists(args.data_path):
+        raise FileNotFoundError(f"Data path {args.data_path} does not exist.")
+
+    if not args.write_split:
+        assert args.decompress and not args.dtype and not args.columns_to_keep, "Only decompression is allowed if no write_split has been specified"
+
+    # Convert args.dtype string into actual np.dtype if given
+    dtype = np.dtype(args.dtype) if args.dtype else None
+
+    # Load index file
+    split_path = os.path.join(args.data_path, args.read_split)
+    index_file_path = os.path.join(split_path, "index.json")
+    obj = json.load(open(index_file_path))
+
+    # Load columns from first shard to know what columns to write, and adapt if columns_to_keep is specified
+    columns_to_write = {col_name: col_enc for col_name, col_enc in zip(obj["shards"][0]["column_names"], obj["shards"][0]["column_encodings"])}
+    if args.columns_to_keep:
+        # Verify that each column in columns_to_keep is valid
+        for column in args.columns_to_keep:
+            assert column in columns_to_write, f"The given column to keep {column} must exist in the data in {args.read_split}"
+        columns_to_write = {col_name: col_encoding for col_name, col_encoding in columns_to_write.items() if col_name in args.columns_to_keep}
+
+    # read all shards
+    shards = []
+    for info in obj['shards']:
+        shard = reader_from_json(args.data_path, args.read_split, info)
+        maybe_decompress_shard(shard, args.keep_zip)
+        shards += [s for s in shard]
+
+    # potentially filter/alter shards and write the new ones
+    if args.write_split:
+        with MDSWriter(
+            columns=columns_to_write, out=os.path.join(args.data_path, args.write_split), compression=args.compression
+        ) as out:
+            for sample in tqdm(shards):
+                if dtype:
+                    assert np.all(sample["input_ids"]<=np.iinfo(dtype).max), f"value in sample[input_ids] must not exceed {dtype} max"
+                    sample["input_ids"] = sample["input_ids"].astype(dtype)
+                out.write({k: sample[k] for k in columns_to_write.keys()})
+    
+if __name__ == "__main__":
+    main()

--- a/src/text_data.py
+++ b/src/text_data.py
@@ -4,6 +4,7 @@
 """Build a StreamingTextDataset dataset and dataloader for training."""
 
 import os
+import json
 from itertools import islice
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
@@ -13,8 +14,12 @@ import transformers
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from streaming import Stream, StreamingDataset
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.distributed import DistributedSampler
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
+from streaming.base.format import reader_from_json
+from streaming.base.spanner import Spanner
+from composer.utils import dist
 
 from transformers.tokenization_utils_base import BatchEncoding
 
@@ -234,19 +239,11 @@ class ConcatenatedSequenceCollatorWrapper:
         return torch.cat([left_zeros, cumulative_sep[:, :-1]], dim=1)
 
 
-def build_text_dataloader(
+def build_streaming_dataset(
     cfg: DictConfig,
     tokenizer: Tokenizer,
     device_batch_size: int,
 ):
-    assert cfg.name == "text", f"Tried to build text dataloader with cfg.name={cfg.name}"
-    if cfg.dataset.get("group_method", None) is not None:
-        raise NotImplementedError(
-            "group_method is deprecated and has been removed.\nTo "
-            + "concatenate, use the --concat_tokens "
-            + "argument when creating your MDS dataset with convert_dataset.py"
-        )
-
     # build streams
     streams_dict = cfg.dataset.get("streams", None)
     streams = None
@@ -289,6 +286,46 @@ def build_text_dataloader(
         shuffle_algo=cfg.dataset.get("shuffle_algo", "py1s"),
         shuffle_seed=cfg.dataset.get("shuffle_seed", 9176),
     )
+    return dataset
+
+def build_no_streaming_dataset(
+    cfg: DictConfig,
+    tokenizer: Tokenizer,
+):
+    return NoStreamingDataset(    
+        tokenizer=tokenizer,
+        local=cfg.dataset.get("local", None),
+        split=cfg.dataset.get("split", None),
+        max_seq_len=cfg.dataset.max_seq_len,
+    )
+
+def build_text_dataloader(
+    cfg: DictConfig,
+    tokenizer: Tokenizer,
+    device_batch_size: int,
+):
+    assert cfg.name == "text", f"Tried to build text dataloader with cfg.name={cfg.name}"
+    if cfg.dataset.get("group_method", None) is not None:
+        raise NotImplementedError(
+            "group_method is deprecated and has been removed.\nTo "
+            + "concatenate, use the --concat_tokens "
+            + "argument when creating your MDS dataset with convert_dataset.py"
+        )
+
+    if cfg.dataset.get("streaming", True):
+        dataset = build_streaming_dataset(cfg, tokenizer, device_batch_size)
+        sampler = None
+    else:
+        assert cfg.dataset.get("local", None) is not None, "Local path must be provided when not using streaming"
+        dataset = build_no_streaming_dataset(cfg, tokenizer)
+        sampler = DistributedSampler(
+            dataset, 
+            num_replicas=dist.get_world_size(), 
+            rank=dist.get_global_rank(), 
+            shuffle=cfg.dataset.get("shuffle", False),
+            seed=cfg.dataset.get("shuffle_seed", 9176),
+            drop_last=cfg.drop_last
+            )
 
     mlm_probability = cfg.dataset.get("mlm_probability", None)
     collate_fn = transformers.DataCollatorForLanguageModeling(
@@ -313,8 +350,58 @@ def build_text_dataloader(
         prefetch_factor=cfg.get("prefetch_factor", 2),
         persistent_workers=cfg.get("persistent_workers", True),
         timeout=cfg.get("timeout", 0),
+        sampler=sampler
     )
 
+
+class NoStreamingDataset(Dataset):
+    """
+    A dataset class that can read data with mds-format (mosaic streaming-format) from local.
+    In comparison with `StreamingTextDataset` that also can read data with mds-format from local, 
+    this class is slimmer, more efficient, and does not contain redundant code required for streaming.
+    """
+    def __init__(self, local: str, split: str, max_seq_len: int, tokenizer: Optional[Tokenizer] = None) -> None:
+        super().__init__()
+        split_path = os.path.join(local,split)
+        index_file_path = os.path.join(split_path, "index.json")
+        obj = json.load(open(index_file_path))
+        self.shards = []
+        for info in obj['shards']:
+            shard = reader_from_json(local, split, info)
+            shard.validate(True)
+            self.shards.append(shard)
+        samples_per_shard = np.array([shard.samples for shard in self.shards], np.int64)
+        self.len = samples_per_shard.sum()
+        self.spanner = Spanner(samples_per_shard)
+        self.max_seq_len = max_seq_len
+        self.tokenizer = tokenizer
+
+    def _tokenize(self, text_sample):
+        assert self.tokenizer is not None, "Tokenizer required if data is not pretokenized"
+        if self.tokenizer._pad_token is None:
+            # Some tokenizers (e.g. GPT2 tokenizer) have no padding token which causes bugs
+            raise RuntimeError("If tokenizing on-the-fly, tokenizer must have a pad_token_id")
+
+        return self.tokenizer(text_sample["text"], truncation=True, padding="max_length", max_length=self.max_seq_len)
+
+    def __getitem__(self, index: int):
+        shard_id, shard_sample_id = self.spanner[index]
+        shard = self.shards[shard_id]
+        sample = shard[shard_sample_id]
+        if "input_ids" in sample:
+            for k in list(sample.keys()):
+                if isinstance(sample[k], np.ndarray):
+                    sample[k] = sample[k][:self.max_seq_len]
+                else:
+                    del sample[k]
+            return sample
+        elif "text" in sample:
+            return self._tokenize(sample)
+        else:
+            RuntimeError("Data sample must contain a field with `input_ids` or `text`")
+
+    def __len__(self):
+        return self.len
 
 # Helpful to test if your dataloader is working locally
 # Run `python data.py  --local_path [local] [--remote_path remote, optional]` and verify that batches are printed out

--- a/src/text_data.py
+++ b/src/text_data.py
@@ -356,8 +356,8 @@ def build_text_dataloader(
 
 class NoStreamingDataset(Dataset):
     """
-    A dataset class that can read data with mds-format (mosaic streaming-format) from local.
-    In comparison with `StreamingTextDataset` that also can read data with mds-format from local, 
+    A dataset class that can read data with raw mds-format (mosaic streaming-format without compression)
+    from local. In comparison with `StreamingTextDataset` that also can read data with mds-format from local, 
     this class is slimmer, more efficient, and does not contain redundant code required for streaming.
     """
     def __init__(self, local: str, split: str, max_seq_len: int, tokenizer: Optional[Tokenizer] = None) -> None:
@@ -368,6 +368,8 @@ class NoStreamingDataset(Dataset):
         self.shards = []
         for info in obj['shards']:
             shard = reader_from_json(local, split, info)
+            raw_filename = os.path.join(shard.dirname, shard.split, shard.raw_data.basename)
+            assert os.path.isfile(raw_filename), f"Raw file {raw_filename} does not exist"
             shard.validate(True)
             self.shards.append(shard)
         samples_per_shard = np.array([shard.samples for shard in self.shards], np.int64)


### PR DESCRIPTION
**Changes**

This PR enables using data with mds-format (mosaic-streaming format) stored locally without using `StreamingTextDataset`.  The new class `NoStreamingDataset` is slimmer, enables higher throughput, and allows to avoid shortcomings with `StreamingTextDataset` such as uneven memory allocations over GPU:s (described in this [issue](https://github.com/mosaicml/streaming/issues/716)), as well shared memory issues.

To use `NoStreamingDataset`, streaming should be set to false in the yaml-configs (see example below):

```
train_loader:
  name: text
  dataset:
    streaming: false
```

**Tests**

I have managed to reproduce very similar loss curves with and without streaming for both text data and pre-tokenized data in a multi-gpu setup, using the `flex-bert-base.yaml`-config. As we use different sampling for the data loader with and without streaming, I did not manage to get the exact same data ordering for my comparisons with and without streaming - which together with non-determinism in flash attention is why the loss curves were not fully identical (but nonetheless very similar). With the `flex-bert-base.yaml`-config, I get ~20 % higher throughput without streaming for text-data, and ~25 % higher throughput without streaming for pretokenized data.

I have not had time to adapt any other tests for this PR, and will be unavailable for the next 9 days. I might be able to answer to comments on this PR, but if new commits or additional tests are found necessary I won't be able to do it during this time. So feel free to contribute with additional commits if necessary while I am away :)