### PR TITLE
Surface cache_limit option for streaming dataloaders

### DIFF
--- a/src/text_data.py
+++ b/src/text_data.py
@@ -107,6 +107,7 @@ class StreamingTextDataset(StreamingDataset):
         shuffle: bool = False,
         shuffle_algo: str = "py1s",
         shuffle_seed: int = 9176,
+        cache_limit: Optional[int] = None,
         **kwargs: Dict[str, Any],
     ):
         group_method = kwargs.pop("group_method", None)
@@ -144,6 +145,7 @@ class StreamingTextDataset(StreamingDataset):
             shuffle=shuffle,
             shuffle_algo=shuffle_algo,
             shuffle_seed=shuffle_seed,
+            cache_limit=cache_limit,
         )
         self.tokenizer = tokenizer
         self.max_seq_len = max_seq_len
@@ -288,6 +290,7 @@ def build_text_dataloader(
         shuffle=cfg.dataset.get("shuffle", False),
         shuffle_algo=cfg.dataset.get("shuffle_algo", "py1s"),
         shuffle_seed=cfg.dataset.get("shuffle_seed", 9176),
+        cache_limit=cfg.dataset.get("cache_limit", None),
     )
 
     mlm_probability = cfg.dataset.get("mlm_probability", None)


### PR DESCRIPTION
We can now set the [MDS cache_limit](https://docs.mosaicml.com/projects/streaming/en/stable/dataset_configuration/shard_retrieval.html#cache-limit) via the dataloader's yaml:

```diff
# Dataloaders
train_loader:
  name: text
  dataset:
    local: ${data_local}
    remote: ${data_remote}
    split: train
    tokenizer_name: ${tokenizer_name}
    max_seq_len: ${max_seq_len}
    shuffle: true
    mlm_probability: ${mlm_probability}
+   cache_limit: 50gb
  drop_last: true
  num_workers: 16
```
When the cache limit isn't set, MDS will remove the unneeded compressed shards by default, but will accumulate the uncompress shards on disk.