### PR TITLE
Add Z-Loss support, use flash_attn CrossEntropy, don't recalculate CrossEntropy metric if unneeded

### DIFF
--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -1,6 +1,8 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 from transformers import BertConfig as TransformersBertConfig
 
 
@@ -135,6 +137,7 @@ class FlexBertConfig(TransformersBertConfig):
             num_initial_layers (int): Number of initial layers to set via `initial_attention_layer`, `initial_bert_layer`, and `initial_mlp_layer`.
             skip_first_prenorm (bool): Skip pre-normalization for the first bert layer. Requires `embed_norm=True`.
             deterministic_fa2 (bool): Use Flash Attention 2 deterministic mode. This is slower then the default non-deterministic mode.
+
             **kwargs: Additional keyword arguments.
         """
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
@@ -184,6 +187,16 @@ class FlexBertConfig(TransformersBertConfig):
         self.num_initial_layers = num_initial_layers
         self.skip_first_prenorm = skip_first_prenorm
         self.deterministic_fa2 = deterministic_fa2
+        if loss_kwargs.get("return_z_loss", False):
+            if loss_function != "fa_cross_entropy":
+                raise ValueError("loss_function must be 'fa_cross_entropy' when return_z_loss is True")
+            if loss_kwargs.get("lse_square_scale", 0) <= 0:
+                raise ValueError(
+                    "lse_square_scale must be passed to `loss_kwargs` and must be greater than 0 for z_loss"
+                )
+        if loss_kwargs.get("inplace_backward", False):
+            self.loss_kwargs["inplace_backward"] = False
+            warnings.warn("`inplace_backward=True` will cause incorrect metrics. Automatically setting to False.")
 
 
 PADDING = ["unpadded", "padded"]

--- a/src/bert_layers/loss.py
+++ b/src/bert_layers/loss.py
@@ -5,12 +5,19 @@ import inspect
 import torch.nn as nn
 from .configuration_bert import FlexBertConfig
 
+try:
+    from flash_attn.losses.cross_entropy import CrossEntropyLoss
+except ImportError:
+    CrossEntropyLoss = None
 
 LOSS2CLS = {
     "cross_entropy": nn.CrossEntropyLoss,
     "binary_cross_entropy": nn.BCEWithLogitsLoss,
     "mean_squared_error": nn.MSELoss,
 }
+
+if CrossEntropyLoss is not None:
+    LOSS2CLS["fa_cross_entropy"] = CrossEntropyLoss
 
 
 def get_loss_fn(config: FlexBertConfig) -> nn.Module:

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -77,6 +77,11 @@ def test_trainer(padding: str, layer: str, embedding: str, attention: str, mlp: 
     if config.model.model_config.init_fn != InitFnType.full_megatron:
         config.model.model_config.init_small_embedding = random.choice([True, False])
 
+    # pick a random loss function for testing
+    config.model.model_config.loss_function = random.choice(["cross_entropy", "fa_cross_entropy"])
+    if config.model.model_config.loss_function == "fa_cross_entropy":
+        config.model.model_config.loss_kwargs["lse_square_scale"] = random.choice([1e-4, 0])
+
     with SynthTextDirectory() as tmp_datadir:
         config.model.model_config.use_fa2 = False
         if padding == "unpadded":

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -16,6 +16,7 @@ run_name: flex-bert-base-parallel
 # Model
 model:
   name: flex_bert
+  recompute_metric_loss: false # recompute metric loss, use if passing label_smoothing to record non-label-smoothed loss as a metric
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
   # FlexBERT 'base' generally uses the default architecture values for from the Hugging Face BertConfig object
@@ -34,7 +35,7 @@ model:
     embed_norm: False
     final_norm: True
     embedding_layer: absolute_pos
-    loss_function: cross_entropy
+    loss_function: fa_cross_entropy
     loss_kwargs:
       reduction: mean
     mlp_dropout_prob: 0.0

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -16,6 +16,7 @@ run_name: flex-bert-base
 # Model
 model:
   name: flex_bert
+  recompute_metric_loss: false # recompute metric loss, use if passing label_smoothing to record non-label-smoothed loss as a metric
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
   # FlexBERT 'base' generally uses the default architecture values for from the Hugging Face BertConfig object
@@ -34,7 +35,7 @@ model:
     embed_norm: false
     final_norm: true
     embedding_layer: absolute_pos
-    loss_function: cross_entropy
+    loss_function: fa_cross_entropy
     loss_kwargs:
       reduction: mean
     mlp_dropout_prob: 0.0

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -16,6 +16,7 @@ run_name: flex-bert-rope-base
 # Model
 model:
   name: flex_bert
+  recompute_metric_loss: false # recompute metric loss, use if passing label_smoothing to record non-label-smoothed loss as a metric
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
   # FlexBERT 'base' generally uses the default architecture values from the Hugging Face BertConfig object
@@ -34,7 +35,7 @@ model:
     embed_norm: false
     final_norm: true
     embedding_layer: sans_pos
-    loss_function: cross_entropy
+    loss_function: fa_cross_entropy
     loss_kwargs:
       reduction: mean
     mlp_dropout_prob: 0.0

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -16,6 +16,7 @@ run_name: flex-bert-rope-parallel-firstprenorm
 # Model
 model:
   name: flex_bert
+  recompute_metric_loss: false # recompute metric loss, use if passing label_smoothing to record non-label-smoothed loss as a metric
   pretrained_model_name: ${tokenizer_name}
   tokenizer_name: ${tokenizer_name}
   # FlexBERT 'base' generally uses the default architecture values for from the Hugging Face BertConfig object
@@ -34,7 +35,7 @@ model:
     embed_norm: true
     final_norm: true
     embedding_layer: sans_pos
-    loss_function: cross_entropy
+    loss_function: fa_cross_entropy
     loss_kwargs:
       reduction: mean
     mlp_dropout_prob: 0.0


### PR DESCRIPTION
This PR adds support for Z-Loss by using Flash Attention's CrossEntropy loss function and uses FA's CE by default. It also doesn't recalculate the cross-entropy loss for metrics by default but logs the loss as a metric.

The combined changes result in a ~8.5% training speed increase and ~23% memory reduction (I assume because FA CE doesn't materialize the entire matrix).

If you want to calculate CrossEntropy loss as a metric (perhaps when using label smoothing, but want to record non-label smoothing loss), it appears to at max 1 percent slower.