### PR TITLE
Add token classification eval with CoNLL 2003

### DIFF
--- a/ablation_eval.py
+++ b/ablation_eval.py
@@ -61,6 +61,7 @@ TASK_NAME_TO_CLASS = {
     "wic": superglue_jobs_module.WiCJob,
     "swag": misc_jobs_module.SWAGJob,
     "eurlex": misc_jobs_module.EurlexJob,
+    "conll2003": misc_jobs_module.CoNLL2003Job,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}
@@ -121,7 +122,7 @@ def build_scheduler(cfg):
 
 
 def build_model(
-    cfg: DictConfig, num_labels: int, multiple_choice: bool = False, **kwargs
+    cfg: DictConfig, num_labels: int, multiple_choice: bool = False, token_classification: bool = False, **kwargs
 ):
     if cfg.name == "hf_bert":
         return hf_bert_module.create_hf_bert_classification(
@@ -132,6 +133,7 @@ def build_model(
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             multiple_choice=multiple_choice,
+            token_classification=token_classification,
             **kwargs,
         )
     elif cfg.name == "mosaic_bert":
@@ -143,6 +145,7 @@ def build_model(
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             multiple_choice=multiple_choice,
+            token_classification=token_classification,
             **kwargs,
         )
     elif cfg.name == "flex_bert":
@@ -154,6 +157,7 @@ def build_model(
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             multiple_choice=multiple_choice,
+            token_classification=token_classification,
             **kwargs,
         )
     else:
@@ -295,6 +299,7 @@ def run_job_worker(
             config.model,
             num_labels=task_cls.num_labels,
             multiple_choice=task_cls.multiple_choice,
+            token_classification=task_cls.token_classification,
             custom_eval_metrics=task_cls.custom_eval_metrics,
         ),
         tokenizer_name=config.tokenizer_name,
@@ -463,7 +468,7 @@ def train(config: om.DictConfig) -> None:
         local_pretrain_checkpoint_path = None
 
     # Builds round 1 configs and runs them
-    round_1_task_names = {"mnli", "eurlex"}
+    round_1_task_names = {"mnli", "eurlex", "conll2003"}
     # round_1_task_names = {"mnli", "eurlex", "boolq", "wic"}
 
     round_1_job_configs = create_job_configs(

--- a/environment.yaml
+++ b/environment.yaml
@@ -426,4 +426,5 @@ dependencies:
       - ninja==1.11.1.1
       - python-snappy==0.7.1
       - scikit-learn==1.5.0
+      - seqeval==1.2.2
       - zstd==1.5.5.1

--- a/glue.py
+++ b/glue.py
@@ -61,6 +61,7 @@ TASK_NAME_TO_CLASS = {
     "wic": superglue_jobs_module.WiCJob,
     "swag": misc_jobs_module.SWAGJob,
     "eurlex": misc_jobs_module.EurlexJob,
+    "conll2003": misc_jobs_module.CoNLL2003Job,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}
@@ -121,7 +122,7 @@ def build_scheduler(cfg):
 
 
 def build_model(
-    cfg: DictConfig, num_labels: int, multiple_choice: bool = False, **kwargs
+    cfg: DictConfig, num_labels: int, multiple_choice: bool = False, token_classification: bool = False, **kwargs
 ):
     if cfg.name == "hf_bert":
         return hf_bert_module.create_hf_bert_classification(
@@ -132,6 +133,7 @@ def build_model(
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             multiple_choice=multiple_choice,
+            token_classification=token_classification,
             **kwargs,
         )
     elif cfg.name == "mosaic_bert":
@@ -143,6 +145,7 @@ def build_model(
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             multiple_choice=multiple_choice,
+            token_classification=token_classification,
             **kwargs,
         )
     elif cfg.name == "flex_bert":
@@ -154,6 +157,7 @@ def build_model(
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             multiple_choice=multiple_choice,
+            token_classification=token_classification,
             **kwargs,
         )
     else:
@@ -294,6 +298,7 @@ def run_job_worker(
             config.model,
             num_labels=task_cls.num_labels,
             multiple_choice=task_cls.multiple_choice,
+            token_classification=task_cls.token_classification,
             custom_eval_metrics=task_cls.custom_eval_metrics,
         ),
         tokenizer_name=config.tokenizer_name,
@@ -468,7 +473,7 @@ def train(config: om.DictConfig) -> None:
         # superglue:
         *{"boolq", "cb", "multirc", "wic"},
         # misc:
-        *{"swag", "eurlex"},
+        *{"swag", "eurlex", "conll2003"},
     }
     round_1_job_configs = create_job_configs(
         config, round_1_task_names, local_pretrain_checkpoint_path

--- a/src/bert_layers/__init__.py
+++ b/src/bert_layers/__init__.py
@@ -25,6 +25,7 @@ from .model import (
     BertForMaskedLM,
     BertForSequenceClassification,
     BertForMultipleChoice,
+    BertForTokenClassification,
     BertOnlyMLMHead,
     BertOnlyNSPHead,
     BertPooler,
@@ -33,6 +34,7 @@ from .model import (
     FlexBertForMaskedLM,
     FlexBertForSequenceClassification,
     FlexBertForMultipleChoice,
+    FlexBertForTokenClassification,
 )
 
 
@@ -42,6 +44,7 @@ __all__ = [
     "BertForMaskedLM",
     "BertForSequenceClassification",
     "BertForMultipleChoice",
+    "BertForTokenClassification",
     "BertResidualGLU",
     "BertAlibiLayer",
     "BertLMPredictionHead",
@@ -65,4 +68,5 @@ __all__ = [
     "FlexBertForMaskedLM",
     "FlexBertForSequenceClassification",
     "FlexBertForMultipleChoice",
+    "FlexBertForTokenClassification",
 ]

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -1442,7 +1442,7 @@ class FlexBertForTokenClassification(BertPreTrainedModel):
             position_ids=position_ids,
         )
 
-        sequence_output = outputs[0]
+        sequence_output = outputs
         sequence_output = self.dropout(sequence_output)
         logits = self.classifier(sequence_output)
 

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -156,3 +156,10 @@ def create_eurlex_dataset(**kwargs):
         dataset_subset="eurlex",
         task_column_names={"coastalcph/lex_glue": ("text",)},
     )
+
+def create_conll2003_dataset(**kwargs):
+    return create_eval_dataset(
+        **kwargs,
+        dataset_name="eriktks/conll2003",
+        task_column_names={"conll2003": ("tokens",)},
+    )

--- a/src/evals/finetuning_jobs.py
+++ b/src/evals/finetuning_jobs.py
@@ -214,6 +214,7 @@ class FineTuneJob:
 class ClassificationJob(FineTuneJob):
     custom_eval_metrics = []
     multiple_choice = False
+    token_classification = False
 
     def __init__(
         self,

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -254,7 +254,7 @@ class EurlexJob(ClassificationJob):
 
         self.evaluators = [eurlex_evaluator]
 
-class CoNLLEval(torchmetrics.Metric):
+class CoNLL2003Eval(torchmetrics.Metric):
     def __init__(self):
         super().__init__()
         self.metric = evaluate.load("seqeval")
@@ -292,7 +292,7 @@ class CoNLL2003Job(ClassificationJob):
     """CoNLL-2003 named entity recognition."""
     num_labels = 9
     token_classification = True
-    custom_eval_metrics = [CoNLLEval]
+    custom_eval_metrics = [CoNLL2003Eval]
 
     def __init__(
         self,
@@ -392,7 +392,7 @@ class CoNLL2003Job(ClassificationJob):
         conll_evaluator = Evaluator(
             label="conll_evaluator",
             dataloader=build_dataloader(ner_eval_dataset, **dataloader_kwargs),
-            metric_names=["CoNLLEval"],
+            metric_names=["CoNLL2003Eval"],
         )
 
         self.evaluators = [conll_evaluator]

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -6,6 +6,9 @@ import os
 import sys
 from itertools import chain
 from typing import List, Optional
+import evaluate
+import torch
+import torchmetrics
 
 # Add glue folder root to path to allow us to use relative imports regardless of what directory the script is run from
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
@@ -16,7 +19,7 @@ from composer.core.evaluator import Evaluator
 from composer.loggers import LoggerDestination
 from composer.optim import ComposerScheduler, DecoupledAdamW
 from torchmetrics.classification import MultilabelF1Score
-from src.evals.data import create_swag_dataset, create_eurlex_dataset
+from src.evals.data import create_swag_dataset, create_eurlex_dataset, create_conll2003_dataset
 from src.evals.finetuning_jobs import (
     build_dataloader,
     multiple_choice_collate_fn,
@@ -250,3 +253,146 @@ class EurlexJob(ClassificationJob):
         )
 
         self.evaluators = [eurlex_evaluator]
+
+class CoNLLEval(torchmetrics.Metric):
+    def __init__(self):
+        super().__init__()
+        self.metric = evaluate.load("seqeval")
+        self.predictions = []
+        self.references = []
+        self.label_names = ["O", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "B-MISC", "I-MISC"]
+
+    def update(self, outputs, labels):
+        predictions = outputs.argmax(dim=-1)
+        predictions = predictions.detach().cpu().numpy()
+        labels = labels.detach().cpu().numpy()
+
+        true_predictions = [
+            [self.label_names[p] for (p, l) in zip(prediction, label) if l != -100]
+            for prediction, label in zip(predictions, labels)
+        ]
+        true_labels = [
+            [self.label_names[l] for l in label if l != -100]
+            for label in labels
+        ]
+
+        self.predictions.extend(true_predictions)
+        self.references.extend(true_labels)
+
+    def compute(self):
+        results = self.metric.compute(predictions=self.predictions, references=self.references)
+        return torch.tensor(results["overall_f1"], dtype=torch.float32)
+
+    def reset(self):
+        self.predictions = []
+        self.references = []
+
+
+class CoNLL2003Job(ClassificationJob):
+    """CoNLL-2003 named entity recognition."""
+    num_labels = 9
+    token_classification = True
+    custom_eval_metrics = [CoNLLEval]
+
+    def __init__(
+        self,
+        model: ComposerModel,
+        tokenizer_name: str,
+        job_name: Optional[str] = None,
+        seed: int = 42,
+        eval_interval: str = "1600ba",
+        scheduler: Optional[ComposerScheduler] = None,
+        max_sequence_length: Optional[int] = 512,
+        max_duration: Optional[str] = "3ep",
+        batch_size: Optional[int] = 16,
+        load_path: Optional[str] = None,
+        save_folder: Optional[str] = None,
+        loggers: Optional[List[LoggerDestination]] = None,
+        callbacks: Optional[List[Callback]] = None,
+        precision: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model=model,
+            tokenizer_name=tokenizer_name,
+            job_name=job_name,
+            seed=seed,
+            task_name="conll2003",
+            eval_interval=eval_interval,
+            scheduler=scheduler,
+            max_sequence_length=max_sequence_length,
+            max_duration=max_duration,
+            batch_size=batch_size,
+            load_path=load_path,
+            save_folder=save_folder,
+            loggers=loggers,
+            callbacks=callbacks,
+            precision=precision,
+            **kwargs,
+        )
+
+        self.optimizer = DecoupledAdamW(
+            self.model.parameters(),
+            lr=5.0e-5,
+            betas=(0.9, 0.98),
+            eps=1.0e-06,
+            weight_decay=1.0e-06,
+        )
+
+
+        def tokenize_fn_factory(tokenizer, max_seq_length: int, label_all_tokens: bool = True):
+            def tokenize_fn(inp):
+                first_sentences = inp["tokens"]
+
+                tokenized_examples = tokenizer(
+                    first_sentences,
+                    padding="max_length",
+                    max_length=max_seq_length,
+                    truncation=True,
+                    is_split_into_words=True,
+                )
+                labels = []
+                for i, label in enumerate(inp["ner_tags"]):
+                    word_ids = tokenized_examples.word_ids(batch_index=i)
+                    previous_word_idx = None
+                    label_ids = []
+                    for word_idx in word_ids:
+                        if word_idx is None:
+                            label_ids.append(-100)
+                        elif word_idx != previous_word_idx:
+                            label_ids.append(label[word_idx])
+                        else:
+                            label_ids.append(label[word_idx] if label_all_tokens else -100)
+                        previous_word_idx = word_idx
+                    labels.append(label_ids)
+                tokenized_examples["labels"] = labels
+                return tokenized_examples
+            return tokenize_fn
+
+        dataset_kwargs = {
+            "task": self.task_name,
+            "tokenizer_name": self.tokenizer_name,
+            "max_seq_length": self.max_sequence_length,
+            "tokenize_fn_factory": tokenize_fn_factory,
+        }
+
+        dataloader_kwargs = {
+            "batch_size": self.batch_size,
+            "num_workers": 0,
+            "drop_last": False,
+        }
+
+        ner_train_dataset = create_conll2003_dataset(split="train", **dataset_kwargs)
+        ner_eval_dataset = create_conll2003_dataset(split="test", **dataset_kwargs)
+        unwanted_columns = ["id", "pos_tags", "chunk_tags", "ner_tags"]
+        ner_train_dataset = ner_train_dataset.remove_columns(unwanted_columns)
+        ner_eval_dataset = ner_eval_dataset.remove_columns(unwanted_columns)        
+        self.train_dataloader = build_dataloader(ner_train_dataset,  **dataloader_kwargs)
+
+        conll_evaluator = Evaluator(
+            label="conll_evaluator",
+            dataloader=build_dataloader(ner_eval_dataset, **dataloader_kwargs),
+            metric_names=["CoNLLEval"],
+        )
+
+        self.evaluators = [conll_evaluator]

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -389,10 +389,10 @@ class CoNLL2003Job(ClassificationJob):
         ner_eval_dataset = ner_eval_dataset.remove_columns(unwanted_columns)        
         self.train_dataloader = build_dataloader(ner_train_dataset,  **dataloader_kwargs)
 
-        conll_evaluator = Evaluator(
-            label="conll_evaluator",
+        conll2003_evaluator = Evaluator(
+            label="conll2003_evaluator",
             dataloader=build_dataloader(ner_eval_dataset, **dataloader_kwargs),
             metric_names=["CoNLL2003Eval"],
         )
 
-        self.evaluators = [conll_evaluator]
+        self.evaluators = [conll2003_evaluator]

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -311,6 +311,7 @@ def create_flex_bert_classification(
     pretrained_checkpoint: Optional[str] = None,
     custom_eval_metrics: Optional[list] = [],
     multiple_choice: Optional[bool] = False,
+    token_classification: Optional[bool] = False,
 ):
     """FlexBERT classification model based on |:hugging_face:| Transformers.
 
@@ -415,6 +416,9 @@ def create_flex_bert_classification(
     if multiple_choice:
         model_cls = bert_layers_module.FlexBertForMultipleChoice
 
+    if token_classification:
+        model_cls = bert_layers_module.FlexBertForTokenClassification
+
     if isinstance(model_config, DictConfig):
         model_config = OmegaConf.to_container(model_config, resolve=True)
 
@@ -454,6 +458,9 @@ def create_flex_bert_classification(
         metrics = [
             MultilabelAccuracy(num_labels=num_labels, average="micro"),
         ]
+
+    if model_config.get("problem_type", "") == "token_classification":
+        metrics = []
 
     hf_model = HuggingFaceModel(
         model=model,

--- a/src/hf_bert.py
+++ b/src/hf_bert.py
@@ -127,6 +127,7 @@ def create_hf_bert_classification(
     gradient_checkpointing: Optional[bool] = False,
     custom_eval_metrics: Optional[list] = [],
     multiple_choice: Optional[bool] = False,
+    token_classification: Optional[bool] = False,
 ):
     """BERT model based on |:hugging_face:| Transformers.
 
@@ -209,6 +210,9 @@ def create_hf_bert_classification(
     if multiple_choice:
         auto_model_cls = transformers.AutoModelForMultipleChoice
 
+    if token_classification:
+        auto_model_cls = transformers.AutoModelForTokenClassification
+
     if use_pretrained:
         assert (
             auto_model_cls.from_pretrained is not None
@@ -250,6 +254,9 @@ def create_hf_bert_classification(
         metrics = [
             MultilabelAccuracy(num_labels=num_labels, average="micro"),
         ]
+
+    if model_config.get("problem_type", "") == "token_classification":
+        metrics = []
 
     return HuggingFaceModel(
         model=model,

--- a/src/mosaic_bert.py
+++ b/src/mosaic_bert.py
@@ -151,6 +151,7 @@ def create_mosaic_bert_classification(
     pretrained_checkpoint: Optional[str] = None,
     custom_eval_metrics: Optional[list] = [],
     multiple_choice: Optional[bool] = False,
+    token_classification: Optional[bool] = False,
 ):
     """Mosaic BERT classification model based on |:hugging_face:| Transformers.
 
@@ -263,6 +264,9 @@ def create_mosaic_bert_classification(
     if multiple_choice:
         model_cls = bert_layers_module.BertForMultipleChoice
 
+    if token_classification:
+        model_cls = bert_layers_module.BertForTokenClassification
+
     config, unused_kwargs = transformers.AutoConfig.from_pretrained(
         pretrained_model_name, return_unused_kwargs=True, **model_config
     )
@@ -303,6 +307,10 @@ def create_mosaic_bert_classification(
         metrics = [
             MultilabelAccuracy(num_labels=num_labels, average="micro"),
         ]
+
+    if model_config.get("problem_type", "") == "token_classification":
+        metrics = []
+
     allow_embedding_resizing = (
         model.config.allow_embedding_resizing if hasattr(model.config, "allow_embedding_resizing") else False
     )

--- a/tests/smoketest_config_ablation_eval.yaml
+++ b/tests/smoketest_config_ablation_eval.yaml
@@ -59,3 +59,11 @@ tasks:
       eval_subset_num_batches: 2
     model_config:
       problem_type: multi_label_classification
+  conll2003:
+    seeds: [23]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0
+      max_duration: 2ba
+      eval_subset_num_batches: 2
+    model_config:
+      problem_type: token_classification

--- a/yamls/ablations/flex-bert-ablation-eval.yaml
+++ b/yamls/ablations/flex-bert-ablation-eval.yaml
@@ -98,3 +98,9 @@ tasks:
       save_num_checkpoints_to_keep: 0
     model_config:
       problem_type: multi_label_classification
+  conll2003:
+    seeds: [23]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0
+    model_config:
+      problem_type: token_classification

--- a/yamls/ablations/hf-bert-ablation-eval.yaml
+++ b/yamls/ablations/hf-bert-ablation-eval.yaml
@@ -57,3 +57,9 @@ tasks:
       save_num_checkpoints_to_keep: 0
     model_config:
       problem_type: multi_label_classification
+  conll2003:
+    seeds: [23]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0
+    model_config:
+      problem_type: token_classification

--- a/yamls/ablations/mosaic-bert-ablation-eval.yaml
+++ b/yamls/ablations/mosaic-bert-ablation-eval.yaml
@@ -59,3 +59,9 @@ tasks:
       save_num_checkpoints_to_keep: 0
     model_config:
       problem_type: multi_label_classification
+  conll2003:
+    seeds: [23]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0
+    model_config:
+      problem_type: token_classification

--- a/yamls/baselines/bert-base-uncased.yaml
+++ b/yamls/baselines/bert-base-uncased.yaml
@@ -71,3 +71,9 @@ tasks:
     seeds: [19, 8364, 717, 10536]
     trainer_kwargs:
       save_num_checkpoints_to_keep: 0
+  conll2003:
+    seeds: [19, 8364, 717, 10536]
+    model_config:
+      problem_type: token_classification
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0


### PR DESCRIPTION
**Changes**

This PR adds support for [CoNLL 2003](https://huggingface.co/datasets/eriktks/conll2003) token classification/entity recognition. It should be easier to integrate other token classification datasets now that the classes have been built out.

Using the `overall_f1` metric from `seqeval`, here are the HF and Mosaic BERT ablations:
- HF BERT: `90.51`
- Mosaic BERT: `60.92`

I trained a quick checkpoint of Flex BERT and verified that this also ran without errors, and got a score of `64.28`. 

Here are the 

**Discussions**
I am not aware of any discussions on the topic, but the `BertForTokenClassification` class was left as TBD. 
https://github.com/AnswerDotAI/bert24/blob/664db039e176085f4689b20ebe7781ca6de2f0ef/src/bert_layers/model.py#L669

**Tests**

- [ ] Is the new feature tested? (Not always necessary for all changes -- just adding to the checklist to keep track)
- [x] Have you ran all the tests?
- [x] Do the tests all pass?
- [ ] If not, have you included an explanation of which tests this PR breaks and/or why (below this checklist)
