### PR TITLE
Add support for local attention

### DIFF
--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -301,11 +301,11 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -459,11 +459,11 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -610,11 +610,11 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
@@ -751,11 +751,11 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -928,11 +928,11 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
@@ -1073,11 +1073,11 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -1244,11 +1244,11 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
@@ -1370,11 +1370,11 @@ class FlexBertPaddedParallelAttention(FlexBertAttentionBase):
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
             if layer_id % config.global_attn_every_n_layers != 0:
-                self.sliding_window = (config.sliding_window, config.sliding_window)
+                self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
             else:
                 self.sliding_window = (-1, -1)
         else:
-            self.sliding_window = (config.sliding_window, config.sliding_window)
+            self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
 
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False

--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -251,6 +251,20 @@ class FlexBertAttentionBase(nn.Module):
     def forward(self, hidden_states: torch.Tensor, attn_mask: torch.Tensor, **kwargs) -> torch.Tensor:
         raise NotImplementedError("This is a base class and should not be used directly.")
 
+    def extra_repr(self) -> str:
+        repr = ""
+        if hasattr(self, "num_attention_heads"):
+            repr += f"num_attention_heads={self.num_attention_heads}"
+        if hasattr(self, "attn_head_size"):
+            repr += f", attn_head_size={self.attn_head_size}"
+        if hasattr(self, "sliding_window"):
+            repr += f", sliding_window={self.sliding_window if self.sliding_window != (-1, -1) else 'False'}"
+        if hasattr(self, "use_fa2"):
+            repr += f", use_fa2={self.use_fa2}"
+        if hasattr(self, "deterministic_fa2"):
+            repr += f", deterministic_fa2={self.deterministic_fa2}"
+        return repr
+
 
 class FlexBertUnpadAttention(FlexBertAttentionBase):
     """Performs multi-headed self attention on a batch of unpadded sequences.
@@ -283,6 +297,16 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
 
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
             logger.warn_once(
@@ -302,6 +326,8 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
                     " use more memory during the backward pass. Use the FA2 backend for linear memory scaling"
                     " with sequence length."
                 )
+            if self.sliding_window[0] > 0:
+                raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -365,6 +391,7 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -374,6 +401,7 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -427,6 +455,16 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
 
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
             logger.warn_once(
@@ -446,6 +484,8 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
                     " use more memory during the backward pass. Use the FA2 backend for linear memory scaling"
                     " with sequence length."
                 )
+            if self.sliding_window[0] > 0:
+                raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -501,6 +541,7 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -510,6 +551,7 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -563,6 +605,17 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
         if self.use_fa2 and self.use_sdpa_attn_mask:
@@ -570,6 +623,8 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
                 "Flash Attention 2 does not support attention masks. Use unpadded attention "
                 "the equivalent functionality of masking out padding tokens."
             )
+        if not self.use_fa2 and self.sliding_window[0] > 0:
+            raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -617,10 +672,20 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
                 orig_dtype = qkv.dtype
                 qkv = qkv.to(torch.bfloat16)
 
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
         else:
             qkv = qkv.view(bs, seqlen, 3, self.num_attention_heads, self.attn_head_size)
 
@@ -682,6 +747,17 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
 
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
+        # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
             logger.warn_once(
                 "Unable to import flash_attn; defaulting FlexBERT attention implementation to PyTorch's"
@@ -700,6 +776,8 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
                     " use more memory during the backward pass. Use the FA2 backend for linear memory scaling"
                     " with sequence length."
                 )
+            if self.sliding_window[0] > 0:
+                raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -768,6 +846,7 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -777,6 +856,7 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -843,11 +923,26 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
             scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
             interleaved=config.rotary_emb_interleaved,
         )
+
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
+        if not IMPL_USE_FLASH2 and self.use_fa2:
+            self.use_fa2 = False
         if self.use_fa2 and self.use_sdpa_attn_mask:
             logger.warn_once(
                 "Flash Attention 2 does not support attention masks. Use unpadded attention "
                 "the equivalent functionality of masking out padding tokens."
             )
+        if not self.use_fa2 and self.sliding_window[0] > 0:
+            raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -901,10 +996,20 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
                 orig_dtype = qkv.dtype
                 qkv = qkv.to(torch.bfloat16)
 
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
         else:
             qkv = self.rotary_emb(qkv, seqlen_offset=seqlen_offset, max_seqlen=None)
             q, k, v = qkv.transpose(3, 1).unbind(dim=2)
@@ -963,6 +1068,18 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
+        # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
             logger.warn_once(
                 "Unable to import flash_attn; defaulting FlexBERT attention implementation to PyTorch's"
@@ -981,6 +1098,8 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
                     " use more memory during the backward pass. Use the FA2 backend for linear memory scaling"
                     " with sequence length."
                 )
+            if self.sliding_window[0] > 0:
+                raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -1042,6 +1161,7 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -1051,6 +1171,7 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
                     max_seqlen=max_seqlen,
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -1119,11 +1240,25 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
             interleaved=config.rotary_emb_interleaved,
         )
 
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
+        if not IMPL_USE_FLASH2 and self.use_fa2:
+            self.use_fa2 = False
         if self.use_fa2 and self.use_sdpa_attn_mask:
             logger.warn_once(
                 "Flash Attention 2 does not support attention masks. Use unpadded attention "
                 "the equivalent functionality of masking out padding tokens."
             )
+        if not self.use_fa2 and self.sliding_window[0] > 0:
+            raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -1170,10 +1305,20 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
                 orig_dtype = qkv.dtype
                 qkv = qkv.to(torch.bfloat16)
 
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
         else:
             qkv = self.rotary_emb(qkv, seqlen_offset=seqlen_offset, max_seqlen=None)
             q, k, v = qkv.transpose(3, 1).unbind(dim=2)
@@ -1220,14 +1365,26 @@ class FlexBertPaddedParallelAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+
+        if config.global_attn_every_n_layers > 0:
+            if config.sliding_window == -1:
+                raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
+            if layer_id % config.global_attn_every_n_layers != 0:
+                self.sliding_window = (config.sliding_window, config.sliding_window)
+            else:
+                self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (config.sliding_window, config.sliding_window)
+
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
-
         if self.use_fa2 and self.use_sdpa_attn_mask:
             logger.warn_once(
                 "Flash Attention 2 does not support attention masks. Use unpadded attention "
                 "the equivalent functionality of masking out padding tokens."
             )
+        if not self.use_fa2 and self.sliding_window[0] > 0:
+            raise ValueError("Sliding window is not implemented for the PyTorch SDPA path. Use the FA2 backend.")
 
     def _init_weights(self, reset_params: bool = False):
         init_weights(
@@ -1268,10 +1425,20 @@ class FlexBertPaddedParallelAttention(FlexBertAttentionBase):
                 orig_dtype = qkv.dtype
                 qkv = qkv.to(torch.bfloat16)
 
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
-                attn = flash_attn_qkvpacked_func(qkv, dropout_p=self.p_dropout, deterministic=self.deterministic_fa2)
+                attn = flash_attn_qkvpacked_func(
+                    qkv,
+                    dropout_p=self.p_dropout,
+                    deterministic=self.deterministic_fa2,
+                    window_size=self.sliding_window,
+                )
         else:
             qkv = qkv.view(bs, seqlen, 3, self.num_attention_heads, self.attn_head_size)
             q, k, v = qkv.transpose(3, 1).unbind(dim=2)  # b h s d

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -206,9 +206,9 @@ class FlexBertConfig(TransformersBertConfig):
             self.loss_kwargs["inplace_backward"] = False
             warnings.warn("`inplace_backward=True` will cause incorrect metrics. Automatically setting to False.")
 
-        if global_attn_every_n_layers > 0 and (self.num_initial_layers - 1) % global_attn_every_n_layers != 0:
+        if global_attn_every_n_layers > 0 and (self.num_hidden_layers - 1) % global_attn_every_n_layers != 0:
             raise ValueError(
-                f"{global_attn_every_n_layers=} must be a divisor of one less than {self.num_initial_layers=}"
+                f"{global_attn_every_n_layers=} must be a divisor of one less than {self.num_hidden_layers=}"
             )
 
 

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -211,11 +211,13 @@ class FlexBertConfig(TransformersBertConfig):
                 f"{global_attn_every_n_layers=} must be a divisor of one less than {self.num_hidden_layers=}"
             )
 
-        if self.sliding_window != -1 and not self.use_fa2:
-            raise ValueError("Sliding window attention is only supported with FlashAttention2")
-
-        if self.sliding_window % 2 != 0 and self.sliding_window % 64 != 0:
-            raise ValueError("Sliding window must be an even number and divisible by 64")
+        if self.sliding_window != -1:
+            if not self.use_fa2:
+                raise ValueError("Sliding window attention is only supported with FlashAttention2")
+            if self.sliding_window % 2 != 0 and self.sliding_window % 64 != 0:
+                raise ValueError(
+                    f"Sliding window must be an even number and divisible by 64: {self.sliding_window=} {self.sliding_window % 64} {self.sliding_window % 2}"
+                )
 
 
 PADDING = ["unpadded", "padded"]

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -89,6 +89,8 @@ class FlexBertConfig(TransformersBertConfig):
         num_initial_layers: int = 1,
         skip_first_prenorm: bool = False,
         deterministic_fa2: bool = False,
+        sliding_window: int = -1,
+        global_attn_every_n_layers: int = -1,
         **kwargs,
     ):
         """
@@ -140,7 +142,8 @@ class FlexBertConfig(TransformersBertConfig):
             num_initial_layers (int): Number of initial layers to set via `initial_attention_layer`, `initial_bert_layer`, and `initial_mlp_layer`.
             skip_first_prenorm (bool): Skip pre-normalization for the first bert layer. Requires `embed_norm=True`.
             deterministic_fa2 (bool): Use Flash Attention 2 deterministic mode. This is slower then the default non-deterministic mode.
-
+            sliding_window (int): Use sliding window attention with window size `n`. -1 to disable.
+            global_attn_every_n_layers (int): Use global attention every `n` layers and sliding window for the rest. -1 to disable.
             **kwargs: Additional keyword arguments.
         """
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
@@ -190,6 +193,8 @@ class FlexBertConfig(TransformersBertConfig):
         self.num_initial_layers = num_initial_layers
         self.skip_first_prenorm = skip_first_prenorm
         self.deterministic_fa2 = deterministic_fa2
+        self.sliding_window = sliding_window
+        self.global_attn_every_n_layers = global_attn_every_n_layers
         if loss_kwargs.get("return_z_loss", False):
             if loss_function != "fa_cross_entropy":
                 raise ValueError("loss_function must be 'fa_cross_entropy' when return_z_loss is True")
@@ -200,6 +205,11 @@ class FlexBertConfig(TransformersBertConfig):
         if loss_kwargs.get("inplace_backward", False):
             self.loss_kwargs["inplace_backward"] = False
             warnings.warn("`inplace_backward=True` will cause incorrect metrics. Automatically setting to False.")
+
+        if global_attn_every_n_layers > 0 and (self.num_initial_layers - 1) % global_attn_every_n_layers != 0:
+            raise ValueError(
+                f"{global_attn_every_n_layers=} must be a divisor of one less than {self.num_initial_layers=}"
+            )
 
 
 PADDING = ["unpadded", "padded"]

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -116,11 +116,11 @@ def test_trainer(
         if sliding_window:
             # fmt: off
             if config.model.model_config.global_attn_every_n_layers == 2:
-                assert model1.bert.encoder.layers[1].attn.sliding_window == (64, 64), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
+                assert model1.bert.encoder.layers[1].attn.sliding_window == (32, 32), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
             else:
-                assert model1.bert.encoder.layers[0].attn.sliding_window == (64, 64), f"Sliding window not set for first layer: {model1.bert.encoder.layers[0].attn}"
-                assert model1.bert.encoder.layers[1].attn.sliding_window == (64, 64), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
-                assert model1.bert.encoder.layers[2].attn.sliding_window == (64, 64), f"Sliding window not set for third layer: {model1.bert.encoder.layers[2].attn}"
+                assert model1.bert.encoder.layers[0].attn.sliding_window == (32, 32), f"Sliding window not set for first layer: {model1.bert.encoder.layers[0].attn}"
+                assert model1.bert.encoder.layers[1].attn.sliding_window == (32, 32), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
+                assert model1.bert.encoder.layers[2].attn.sliding_window == (32, 32), f"Sliding window not set for third layer: {model1.bert.encoder.layers[2].attn}"
         # SDPA doesn't have sliding window impleemnted, so skip the test
         else:
             config.model.model_config.use_fa2 = False

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -41,7 +41,16 @@ layer_combinations = [
 @pytest.mark.parametrize("padding", ["padded", "unpadded"])
 @pytest.mark.parametrize("layer,embedding,attention,mlp", layer_combinations)
 @pytest.mark.parametrize("different_first_layer", [False, True])
-def test_trainer(padding: str, layer: str, embedding: str, attention: str, mlp: str, different_first_layer: bool):
+@pytest.mark.parametrize("sliding_window", [False, True])
+def test_trainer(
+    padding: str,
+    layer: str,
+    embedding: str,
+    attention: str,
+    mlp: str,
+    different_first_layer: bool,
+    sliding_window: bool,
+):
     with open("yamls/defaults.yaml") as f:
         default_cfg = OmegaConf.load(f)
     with open("yamls/models/flex_bert.yaml") as f:
@@ -59,6 +68,11 @@ def test_trainer(padding: str, layer: str, embedding: str, attention: str, mlp: 
     config.model.model_config.mlp_layer = mlp
     if layer == "postnorm":
         config.model.model_config.final_norm = False
+
+    if sliding_window:
+        config.model.model_config.sliding_window = 64
+        config.model.model_config.num_hidden_layers = 3
+        config.model.model_config.global_attn_every_n_layers = random.choice([-1, 2])
 
     if different_first_layer:
         if layer != "parallel_prenorm":
@@ -83,7 +97,7 @@ def test_trainer(padding: str, layer: str, embedding: str, attention: str, mlp: 
         config.model.model_config.loss_kwargs["lse_square_scale"] = random.choice([1e-4, 0])
 
     with SynthTextDirectory() as tmp_datadir:
-        config.model.model_config.use_fa2 = False
+        config.model.model_config.use_fa2 = True
         if padding == "unpadded":
             config.model.model_config.use_sdpa_attn_mask = True
         else:
@@ -93,30 +107,43 @@ def test_trainer(padding: str, layer: str, embedding: str, attention: str, mlp: 
         config.eval_loader.dataset.remote = tmp_datadir
         config.eval_loader.dataset.local = os.path.join(tmp_datadir, "ev-local1")
 
-        # Train with SDPA
+        # Train with FA2
         trainer1 = main(config, return_trainer=True)
         assert trainer1 is not None
         model1 = trainer1.state.model.model
 
-        config.model.model_config.use_fa2 = True
-        config.train_loader.dataset.local = os.path.join(tmp_datadir, "tr-local2")
-        config.eval_loader.dataset.local = os.path.join(tmp_datadir, "ev-local2")
+        # if sliding window is set, there might only be one attention layer with a sliding window
+        if sliding_window:
+            # fmt: off
+            if config.model.model_config.global_attn_every_n_layers == 2:
+                assert model1.bert.encoder.layers[1].attn.sliding_window == (64, 64), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
+            else:
+                assert model1.bert.encoder.layers[0].attn.sliding_window == (64, 64), f"Sliding window not set for first layer: {model1.bert.encoder.layers[0].attn}"
+                assert model1.bert.encoder.layers[1].attn.sliding_window == (64, 64), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
+                assert model1.bert.encoder.layers[2].attn.sliding_window == (64, 64), f"Sliding window not set for third layer: {model1.bert.encoder.layers[2].attn}"
+        # SDPA doesn't have sliding window impleemnted, so skip the test
+        else:
+            config.model.model_config.use_fa2 = False
+            config.train_loader.dataset.local = os.path.join(tmp_datadir, "tr-local2")
+            config.eval_loader.dataset.local = os.path.join(tmp_datadir, "ev-local2")
 
-        # Train with FA2
-        trainer2 = main(config, return_trainer=True)
-        assert trainer2 is not None
-        model2 = trainer2.state.model.model
+            # Train with SDPA
+            trainer2 = main(config, return_trainer=True)
+            assert trainer2 is not None
+            model2 = trainer2.state.model.model
 
-    for param1, param2 in zip(model1.parameters(), model2.parameters()):
-        torch.testing.assert_close(param1, param2, rtol=1e-2, atol=1e-3)
+    # SDPA doesn't have sliding window impleemnted, so skip the comparison
+    if not sliding_window:
+        for param1, param2 in zip(model1.parameters(), model2.parameters()):
+            torch.testing.assert_close(param1, param2, rtol=1e-2, atol=1e-3)
 
-    if different_first_layer:
-        nl = config.model.model_config.num_initial_layers
-        for m in range(2):
-            model = model1 if m == 0 else model2
-            for i in range(nl - 1):
-                assert isinstance(model.bert.encoder.layers[i], type(model.bert.encoder.layers[i + 1]))
-            if nl < len(model.bert.encoder.layers):
-                assert not isinstance(model.bert.encoder.layers[nl - 1], type(model.bert.encoder.layers[nl]))
-                for i in range(nl, len(model1.bert.encoder.layers) - 1):
+        if different_first_layer:
+            nl = config.model.model_config.num_initial_layers
+            for m in range(2):
+                model = model1 if m == 0 else model2
+                for i in range(nl - 1):
                     assert isinstance(model.bert.encoder.layers[i], type(model.bert.encoder.layers[i + 1]))
+                if nl < len(model.bert.encoder.layers):
+                    assert not isinstance(model.bert.encoder.layers[nl - 1], type(model.bert.encoder.layers[nl]))
+                    for i in range(nl, len(model1.bert.encoder.layers) - 1):
+                        assert isinstance(model.bert.encoder.layers[i], type(model.bert.encoder.layers[i + 1]))


### PR DESCRIPTION
This PR adds support for setting local attention by using Flash Attention's built in sliding window support.

It also allows Gemma 2/Character.ai style alternating local/global attention via the `global_attn_every_n_layers` setting. For a 22 layer model, global attention every three layers seems to work quite well, with a maximum measured speedup of ~20% if all samples in a batch are max sequence length. In practice the speedup appears to be in the ~5%. There appears to be no loss in model performance from alternating every three layers.