### PR TITLE
Allow to disable training metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -253,6 +253,7 @@ def build_model(cfg: DictConfig):
             tokenizer_name=cfg.get("tokenizer_name", None),
             gradient_checkpointing=cfg.get("gradient_checkpointing", None),
             recompute_metric_loss=cfg.get("recompute_metric_loss", False),
+            disable_train_metrics=cfg.get("disable_train_metrics", False),
         )
     else:
         raise ValueError(f"Not sure how to build model with name={cfg.name}")

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import copy
 import os
 import sys
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, Optional
 
 import torch
 from torch import Tensor

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import copy
 import os
 import sys
 from typing import Any, Dict, Mapping, Optional, Union
@@ -177,6 +178,7 @@ def create_flex_bert_mlm(
     gradient_checkpointing: Optional[bool] = False,
     pretrained_checkpoint: Optional[str] = None,
     recompute_metric_loss: Optional[bool] = False,
+    disable_train_metrics: Optional[bool] = False,
 ):
     """FlexBERT masked language model based on |:hugging_face:| Transformers.
 
@@ -201,6 +203,9 @@ def create_flex_bert_mlm(
             initialize the model weights. If provided, the state dictionary
             stored at `pretrained_checkpoint` will be loaded into the model
             after initialization. Default: ``None``.
+        disable_train_metrics (bool, optional): Only calculate metrics for 
+            validation set when True.
+            Default: ``False``.
 
     .. code-block::
 
@@ -285,11 +290,16 @@ def create_flex_bert_mlm(
     if model_config.get("loss_kwargs", {}).get("return_z_loss", False):
         metrics += [EfficientZLoss()]
 
+    eval_metrics = copy.deepcopy(metrics)
+    if disable_train_metrics:
+        metrics = None
+
     hf_model = EfficientHuggingFaceModel(
         model=model,
         tokenizer=tokenizer,
         use_logits=True,
         metrics=metrics,
+        eval_metrics=eval_metrics,
         allow_embedding_resizing=model.config.allow_embedding_resizing,
     )
 


### PR DESCRIPTION
These changes allow to disable the computing of training metrics, and thus only calculate metrics on the validation set (which we most want to consider for the longer training runs).

When `disable_train_metrics` is set to `True` in the config, training is speeded up with close to 3 % with my current training setup (one 8XH100 node with a 130M model).

I also corrected some old formatting with ruff in the files I updated.