### PR TITLE
Add support for mds without predefined attention mask

### DIFF
--- a/src/text_data.py
+++ b/src/text_data.py
@@ -167,7 +167,10 @@ class StreamingTextDataset(StreamingDataset):
         seq_len = sample["len"] if "len" in sample else len(sample["input_ids"])
 
         input_ids = np.frombuffer(sample["input_ids"], dtype=np.int64).copy()
-        attention_mask = np.frombuffer(sample["attention_mask"], dtype=np.int64).copy()
+        if "attention_mask" in sample:
+            attention_mask = np.frombuffer(sample["attention_mask"], dtype=np.int64).copy()
+        else:
+            attention_mask = np.ones_like(input_ids)
 
         # calculate padding
         pad_len = self.max_seq_len - seq_len
@@ -399,6 +402,8 @@ class NoStreamingDataset(Dataset):
                     sample[k] = sample[k][:self.max_seq_len]
                 else:
                     del sample[k]
+            if "attention_mask" not in sample:
+                sample["attention_mask"] = np.ones_like(sample["input_ids"])
             return sample
         elif "text" in sample:
             return self._tokenize(sample)


### PR DESCRIPTION
**Changes**

This PR enables reading mds data that does not have a predefined attention_mask.

As the attention mask is redundant to store in mds in our standard case (as it is just an array of ones with the same length as the input_ids), we have removed it in the new batches of data that we are processing. This PR accommodates this update, enabling training with this new format.

With this PR, supporting mds-data requiring less storage, the reads from disk is significantly reduced.

Additionally the conversion script of mds-data has been made more efficient.

**Tests**
I have taken mds-data with predefined attention masks, that I then have removed the attention masked from using the conversion script. Using the original data, and the new data without attention masks, I have achieved close to identical loss curves with and without predefined attention masks. I have verified this both with and without streaming.

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/909d6cb8-bab4-4439-9775-0ac251c637c3">
<img width="1332" alt="image" src="https://github.com/user-attachments/assets/b6ce9b78-28c5-48d3-8a48-c32e67f3f173">
