### PR TITLE
Different RoPE settings for local attention layers

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -103,6 +103,8 @@ def get_model(
         skip_first_prenorm=False,
         sliding_window=sliding_window,
         global_attn_every_n_layers=global_attn_every_n_layers,
+        unpad_embeddings=True,
+        pad_logits=False,
     )
     if model_type == ModelType.mlm:
         config.tie_word_embeddings = True
@@ -243,26 +245,21 @@ def tile_list_to_length(lst, length):
     return lst
 
 
+# fmt: off
 @app.command()
 def main(
     ctx: typer.Context,  # Typer Context to grab config for --verbose and passing to WandB
     hidden_sizes: Annotated[List[int], Option(help="List of hidden sizes", show_default=False)],
     num_hidden_layers: Annotated[List[int], Option(help="List of number of hidden layers", show_default=False)],
     intermediate_sizes: Annotated[List[int], Option(help="List of intermediate sizes", show_default=False)],
-    parallel_attn: Annotated[
-        List[bool], Option(is_flag=False, help="List of parallel attention flags", show_default=False)
-    ],
+    parallel_attn: Annotated[List[bool], Option(is_flag=False, help="List of parallel attention flags", show_default=False)],
     sliding_window: Annotated[List[int], Option(help="Sliding window size. -1 to disable.")] = [-1],
-    global_attn_every_n_layers: Annotated[
-        List[int], Option(help="Use global attention every `n` layers and sliding window for the rest. -1 to disable.")
-    ] = [-1],
+    global_attn_every_n_layers: Annotated[List[int], Option(help="Use global attention every `n` layers and sliding window for the rest. -1 to disable.")] = [-1],
     model_type: Annotated[List[ModelType], Option(help="Model type: MLM or Multiple Choice")] = [ModelType.mlm],
     vocab_size: Annotated[List[int], Option(help="Vocabulary size")] = [32768],
     num_samples: Annotated[int, Option(help="Number of samples")] = 1000,
     seq_length: Annotated[int, Option(help="Sequence length")] = 512,
-    batch_size: Annotated[
-        Optional[int], Option(help="Batch size (if not provided, will be set based on model size)")
-    ] = None,
+    batch_size: Annotated[Optional[int], Option(help="Batch size (if not provided, will be set based on model size)")] = None,
     output_file: Annotated[str, Option(help="Output file name for results")] = "benchmark_results.md",
     sleep_time: Annotated[int, Option(help="Time to sleep between each model run")] = 25,
     print_model: Annotated[bool, Option(help="Print model")] = False,
@@ -277,6 +274,7 @@ def main(
         ),
     ] = None,
 ):
+# fmt: on
     pynvml.nvmlInit()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -732,21 +732,6 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
             nn.Dropout(config.attn_out_dropout_prob) if config.attn_out_dropout_prob > 0.0 else nn.Identity()
         )
 
-        if config.rotary_emb_dim is None:
-            config.rotary_emb_dim = self.attn_head_size
-
-        assert UnpaddedRotaryEmbedding is not None, "rotary_emb is not installed"
-        self.rotary_emb = UnpaddedRotaryEmbedding(
-            config.rotary_emb_dim,
-            base=config.rotary_emb_base,
-            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
-            interleaved=config.rotary_emb_interleaved,
-        )
-
-        self.use_fa2 = config.use_fa2
-        self.deterministic_fa2 = config.deterministic_fa2
-        self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
-
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
@@ -756,6 +741,26 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
                 self.sliding_window = (-1, -1)
         else:
             self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
+
+        if config.rotary_emb_dim is None:
+            config.rotary_emb_dim = self.attn_head_size
+
+        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
+            rotary_base = config.local_attn_rotary_emb_base
+        else:
+            rotary_base = config.rotary_emb_base
+
+        assert UnpaddedRotaryEmbedding is not None, "rotary_emb is not installed"
+        self.rotary_emb = UnpaddedRotaryEmbedding(
+            config.rotary_emb_dim,
+            base=rotary_base,
+            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
+            interleaved=config.rotary_emb_interleaved,
+        )
+
+        self.use_fa2 = config.use_fa2
+        self.deterministic_fa2 = config.deterministic_fa2
+        self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -913,17 +918,6 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
 
-        if config.rotary_emb_dim is None:
-            config.rotary_emb_dim = self.attn_head_size
-
-        assert RotaryEmbedding is not None, "rotary_emb is not installed"
-        self.rotary_emb = RotaryEmbedding(
-            config.rotary_emb_dim,
-            base=config.rotary_emb_base,
-            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
-            interleaved=config.rotary_emb_interleaved,
-        )
-
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
@@ -933,6 +927,22 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
                 self.sliding_window = (-1, -1)
         else:
             self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
+
+        if config.rotary_emb_dim is None:
+            config.rotary_emb_dim = self.attn_head_size
+
+        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
+            rotary_base = config.local_attn_rotary_emb_base
+        else:
+            rotary_base = config.rotary_emb_base
+
+        assert RotaryEmbedding is not None, "rotary_emb is not installed"
+        self.rotary_emb = RotaryEmbedding(
+            config.rotary_emb_dim,
+            base=rotary_base,
+            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
+            interleaved=config.rotary_emb_interleaved,
+        )
 
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
@@ -1054,21 +1064,6 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
             nn.Dropout(config.attn_out_dropout_prob) if config.attn_out_dropout_prob > 0.0 else nn.Identity()
         )
 
-        if config.rotary_emb_dim is None:
-            config.rotary_emb_dim = self.attn_head_size
-
-        assert UnpaddedRotaryEmbedding is not None, "rotary_emb is not installed"
-        self.rotary_emb = UnpaddedRotaryEmbedding(
-            config.rotary_emb_dim,
-            base=config.rotary_emb_base,
-            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
-            interleaved=config.rotary_emb_interleaved,
-        )
-
-        self.use_fa2 = config.use_fa2
-        self.deterministic_fa2 = config.deterministic_fa2
-        self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
-
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
@@ -1078,6 +1073,26 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
                 self.sliding_window = (-1, -1)
         else:
             self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
+
+        if config.rotary_emb_dim is None:
+            config.rotary_emb_dim = self.attn_head_size
+
+        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
+            rotary_base = config.local_attn_rotary_emb_base
+        else:
+            rotary_base = config.rotary_emb_base
+
+        assert UnpaddedRotaryEmbedding is not None, "rotary_emb is not installed"
+        self.rotary_emb = UnpaddedRotaryEmbedding(
+            config.rotary_emb_dim,
+            base=rotary_base,
+            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
+            interleaved=config.rotary_emb_interleaved,
+        )
+
+        self.use_fa2 = config.use_fa2
+        self.deterministic_fa2 = config.deterministic_fa2
+        self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -1229,17 +1244,6 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
 
-        if config.rotary_emb_dim is None:
-            config.rotary_emb_dim = self.attn_head_size
-
-        assert RotaryEmbedding is not None, "rotary_emb is not installed"
-        self.rotary_emb = RotaryEmbedding(
-            config.rotary_emb_dim,
-            base=config.rotary_emb_base,
-            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
-            interleaved=config.rotary_emb_interleaved,
-        )
-
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
                 raise ValueError("global_attn_every_n_layers` requires `sliding_window` to be set")
@@ -1249,6 +1253,22 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
                 self.sliding_window = (-1, -1)
         else:
             self.sliding_window = (config.sliding_window // 2, config.sliding_window // 2)
+
+        if config.rotary_emb_dim is None:
+            config.rotary_emb_dim = self.attn_head_size
+
+        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
+            rotary_base = config.local_attn_rotary_emb_base
+        else:
+            rotary_base = config.rotary_emb_base
+
+        assert RotaryEmbedding is not None, "rotary_emb is not installed"
+        self.rotary_emb = RotaryEmbedding(
+            config.rotary_emb_dim,
+            base=rotary_base,
+            scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
+            interleaved=config.rotary_emb_interleaved,
+        )
 
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False

--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -745,14 +745,17 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
         if config.rotary_emb_dim is None:
             config.rotary_emb_dim = self.attn_head_size
 
-        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
-            rotary_base = config.local_attn_rotary_emb_base
-        else:
-            rotary_base = config.rotary_emb_base
+        rotary_base = config.rotary_emb_base
+        rotary_dim = config.rotary_emb_dim
+        if self.sliding_window != (-1, -1):
+            if config.local_attn_rotary_emb_base != -1:
+                rotary_base = config.local_attn_rotary_emb_base
+            if config.local_attn_rotary_emb_dim is not None:
+                rotary_dim = config.local_attn_rotary_emb_dim
 
         assert UnpaddedRotaryEmbedding is not None, "rotary_emb is not installed"
         self.rotary_emb = UnpaddedRotaryEmbedding(
-            config.rotary_emb_dim,
+            dim=rotary_dim,
             base=rotary_base,
             scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
             interleaved=config.rotary_emb_interleaved,
@@ -931,14 +934,17 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
         if config.rotary_emb_dim is None:
             config.rotary_emb_dim = self.attn_head_size
 
-        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
-            rotary_base = config.local_attn_rotary_emb_base
-        else:
-            rotary_base = config.rotary_emb_base
+        rotary_base = config.rotary_emb_base
+        rotary_dim = config.rotary_emb_dim
+        if self.sliding_window != (-1, -1):
+            if config.local_attn_rotary_emb_base != -1:
+                rotary_base = config.local_attn_rotary_emb_base
+            if config.local_attn_rotary_emb_dim is not None:
+                rotary_dim = config.local_attn_rotary_emb_dim
 
         assert RotaryEmbedding is not None, "rotary_emb is not installed"
         self.rotary_emb = RotaryEmbedding(
-            config.rotary_emb_dim,
+            dim=rotary_dim,
             base=rotary_base,
             scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
             interleaved=config.rotary_emb_interleaved,
@@ -1077,14 +1083,17 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
         if config.rotary_emb_dim is None:
             config.rotary_emb_dim = self.attn_head_size
 
-        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
-            rotary_base = config.local_attn_rotary_emb_base
-        else:
-            rotary_base = config.rotary_emb_base
+        rotary_base = config.rotary_emb_base
+        rotary_dim = config.rotary_emb_dim
+        if self.sliding_window != (-1, -1):
+            if config.local_attn_rotary_emb_base != -1:
+                rotary_base = config.local_attn_rotary_emb_base
+            if config.local_attn_rotary_emb_dim is not None:
+                rotary_dim = config.local_attn_rotary_emb_dim
 
         assert UnpaddedRotaryEmbedding is not None, "rotary_emb is not installed"
         self.rotary_emb = UnpaddedRotaryEmbedding(
-            config.rotary_emb_dim,
+            dim=rotary_dim,
             base=rotary_base,
             scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
             interleaved=config.rotary_emb_interleaved,
@@ -1257,14 +1266,17 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
         if config.rotary_emb_dim is None:
             config.rotary_emb_dim = self.attn_head_size
 
-        if self.sliding_window != (-1, -1) and config.local_attn_rotary_emb_base != -1:
-            rotary_base = config.local_attn_rotary_emb_base
-        else:
-            rotary_base = config.rotary_emb_base
+        rotary_base = config.rotary_emb_base
+        rotary_dim = config.rotary_emb_dim
+        if self.sliding_window != (-1, -1):
+            if config.local_attn_rotary_emb_base != -1:
+                rotary_base = config.local_attn_rotary_emb_base
+            if config.local_attn_rotary_emb_dim is not None:
+                rotary_dim = config.local_attn_rotary_emb_dim
 
         assert RotaryEmbedding is not None, "rotary_emb is not installed"
         self.rotary_emb = RotaryEmbedding(
-            config.rotary_emb_dim,
+            dim=rotary_dim,
             base=rotary_base,
             scale_base=config.rotary_emb_scale_base,  # If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
             interleaved=config.rotary_emb_interleaved,

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -92,6 +92,7 @@ class FlexBertConfig(TransformersBertConfig):
         sliding_window: int = -1,
         global_attn_every_n_layers: int = -1,
         local_attn_rotary_emb_base: float = -1,
+        local_attn_rotary_emb_dim: int | None = None,
         unpad_embeddings: bool = False,
         pad_logits: bool = False,
         **kwargs,
@@ -148,6 +149,7 @@ class FlexBertConfig(TransformersBertConfig):
             sliding_window (int): Use sliding window attention with window size `n`. -1 to disable. Window size split between the left and right context. Only supports FA2.
             global_attn_every_n_layers (int): Use global attention every `n` layers and sliding window for the rest. -1 to disable.
             local_attn_rotary_emb_base (float): Rotary embedding base for local attention. -1 to disable and use `rotary_emb_base` for all layers.
+            local_attn_rotary_emb_dim (int | None): Rotary embedding dimension for local attention. None to disable and use `rotary_emb_dim` for all layers.
             unpad_embeddings (bool): Unpad inputs before the embedding layer.
             pad_logits (bool): Pad logits after the calculating the loss.
             **kwargs: Additional keyword arguments.
@@ -202,6 +204,7 @@ class FlexBertConfig(TransformersBertConfig):
         self.sliding_window = sliding_window
         self.global_attn_every_n_layers = global_attn_every_n_layers
         self.local_attn_rotary_emb_base = local_attn_rotary_emb_base
+        self.local_attn_rotary_emb_dim = local_attn_rotary_emb_dim
         self.unpad_embeddings = unpad_embeddings
         self.pad_logits = pad_logits
 
@@ -233,6 +236,8 @@ class FlexBertConfig(TransformersBertConfig):
                 raise ValueError("global_attn_every_n_layers must be -1 when sliding_window is disabled")
             if self.local_attn_rotary_emb_base != -1:
                 raise ValueError("local_attn_rotary_emb_base must be -1 when sliding_window is disabled")
+            if self.local_attn_rotary_emb_dim is not None:
+                raise ValueError("local_attn_rotary_emb_dim must be None when sliding_window is disabled")
 
         if self.unpad_embeddings and self.padding != "unpadded":
             warnings.warn(

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -91,6 +91,7 @@ class FlexBertConfig(TransformersBertConfig):
         deterministic_fa2: bool = False,
         sliding_window: int = -1,
         global_attn_every_n_layers: int = -1,
+        local_attn_rotary_emb_base: float = -1,
         unpad_embeddings: bool = False,
         pad_logits: bool = False,
         **kwargs,
@@ -146,6 +147,7 @@ class FlexBertConfig(TransformersBertConfig):
             deterministic_fa2 (bool): Use Flash Attention 2 deterministic mode. This is slower then the default non-deterministic mode.
             sliding_window (int): Use sliding window attention with window size `n`. -1 to disable. Window size split between the left and right context. Only supports FA2.
             global_attn_every_n_layers (int): Use global attention every `n` layers and sliding window for the rest. -1 to disable.
+            local_attn_rotary_emb_base (float): Rotary embedding base for local attention. -1 to disable and use `rotary_emb_base` for all layers.
             unpad_embeddings (bool): Unpad inputs before the embedding layer.
             pad_logits (bool): Pad logits after the calculating the loss.
             **kwargs: Additional keyword arguments.
@@ -199,6 +201,7 @@ class FlexBertConfig(TransformersBertConfig):
         self.deterministic_fa2 = deterministic_fa2
         self.sliding_window = sliding_window
         self.global_attn_every_n_layers = global_attn_every_n_layers
+        self.local_attn_rotary_emb_base = local_attn_rotary_emb_base
         self.unpad_embeddings = unpad_embeddings
         self.pad_logits = pad_logits
 
@@ -225,6 +228,11 @@ class FlexBertConfig(TransformersBertConfig):
                 raise ValueError(
                     f"Sliding window must be an even number and divisible by 64: {self.sliding_window=} {self.sliding_window % 64} {self.sliding_window % 2}"
                 )
+        else:
+            if self.global_attn_every_n_layers != -1:
+                raise ValueError("global_attn_every_n_layers must be -1 when sliding_window is disabled")
+            if self.local_attn_rotary_emb_base != -1:
+                raise ValueError("local_attn_rotary_emb_base must be -1 when sliding_window is disabled")
 
         if self.unpad_embeddings and self.padding != "unpadded":
             warnings.warn(

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -67,7 +67,8 @@ from transformers.modeling_outputs import (
 from transformers.models.bert.modeling_bert import BertPreTrainedModel
 from transformers.modeling_outputs import ModelOutput
 
-import bert_padding as bert_padding_module
+from bert_padding import index_put_first_axis
+from .padding import unpad_input, pad_input
 from .loss import get_loss_fn
 from .layers import (
     BertAlibiEncoder,
@@ -375,7 +376,7 @@ class BertForMaskedLM(BertPreTrainedModel):
             assert input_ids is not None, "Coding error; please open an issue"
             batch, seqlen = input_ids.shape[:2]
             prediction_scores = rearrange(
-                bert_padding_module.index_put_first_axis(prediction_scores, masked_token_idx, batch * seqlen),
+                index_put_first_axis(prediction_scores, masked_token_idx, batch * seqlen),
                 "(b s) d -> b s d",
                 b=batch,
             )
@@ -745,6 +746,41 @@ class FlexBertPoolingHead(nn.Module):
 
 
 @dataclass
+class MaskedLMOutput(ModelOutput):
+    """
+    Base class for masked language models outputs.
+
+    Args:
+        loss (`torch.FloatTensor` of shape `(1,)`, *optional*, returned when `labels` is provided):
+            Masked language modeling (MLM) loss.
+        logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.vocab_size)`):
+            Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+        hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple of `torch.FloatTensor` (one for the output of the embeddings, if the model has an embedding layer, +
+            one for the output of each layer) of shape `(batch_size, sequence_length, hidden_size)`.
+
+            Hidden-states of the model at the output of each layer plus the optional initial embedding outputs.
+        attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
+            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
+            sequence_length)`.
+
+            Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
+            heads.
+    """
+
+    loss: Optional[torch.FloatTensor] = None
+    logits: torch.FloatTensor = None
+    hidden_states: Optional[Tuple[torch.FloatTensor, ...]] = None
+    attentions: Optional[Tuple[torch.FloatTensor, ...]] = None
+    indices: Optional[torch.LongTensor] = None
+    cu_seqlens: Optional[torch.LongTensor] = None
+    max_seqlen: Optional[int] = None
+    batch_size: Optional[int] = None
+    seq_len: Optional[int] = None
+    labels: Optional[torch.LongTensor] = None
+
+
+@dataclass
 class MaskedLMOutputZLoss(ModelOutput):
     """
     Base class for masked language models outputs.
@@ -769,6 +805,8 @@ class MaskedLMOutputZLoss(ModelOutput):
 
             Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
             heads.
+        indices (`torch.LongTensor` of shape `(batch_size,)`):
+            Indices of the tokens to be masked.
     """
 
     loss: Optional[torch.FloatTensor] = None
@@ -777,6 +815,12 @@ class MaskedLMOutputZLoss(ModelOutput):
     logits: torch.FloatTensor = None
     hidden_states: Optional[Tuple[torch.FloatTensor, ...]] = None
     attentions: Optional[Tuple[torch.FloatTensor, ...]] = None
+    indices: Optional[torch.LongTensor] = None
+    cu_seqlens: Optional[torch.LongTensor] = None
+    max_seqlen: Optional[int] = None
+    batch_size: Optional[int] = None
+    seq_len: Optional[int] = None
+    labels: Optional[torch.LongTensor] = None
 
 
 class FlexBertModel(BertPreTrainedModel):
@@ -831,6 +875,7 @@ class FlexBertModel(BertPreTrainedModel):
             self.final_norm = get_norm_layer(config)
         else:
             self.final_norm = None
+        self.unpad_embeddings = config.unpad_embeddings
 
     def post_init(self):
         self._init_weights()
@@ -847,6 +892,9 @@ class FlexBertModel(BertPreTrainedModel):
         input_ids: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        indices: Optional[torch.Tensor] = None,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Union[List[torch.Tensor], torch.Tensor], Optional[torch.Tensor]]:
         if attention_mask is None:
@@ -854,7 +902,13 @@ class FlexBertModel(BertPreTrainedModel):
 
         embedding_output = self.embeddings(input_ids, position_ids)
 
-        encoder_outputs = self.encoder(embedding_output, attention_mask)
+        encoder_outputs = self.encoder(
+            hidden_states=embedding_output,
+            attention_mask=attention_mask,
+            indices=indices,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
 
         if self.final_norm is not None:
             encoder_outputs = self.final_norm(encoder_outputs)
@@ -904,6 +958,8 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
         self.loss_fn = nn.CrossEntropyLoss() if not hasattr(config, "loss_function") else get_loss_fn(config)
         self.fa_ce = getattr(config, "loss_function", "cross_entropy") == "fa_cross_entropy"
         self.return_z_loss = config.loss_kwargs.get("return_z_loss", False)
+        self.unpad_embeddings = config.unpad_embeddings
+        self.pad_logits = config.pad_logits
 
         # Initialize weights and apply final processing
         self._init_weights()
@@ -950,6 +1006,16 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         self.decoder = new_embeddings
 
+    @torch.no_grad()
+    def unpad_inputs(
+        self, input_ids: torch.Tensor, attention_mask: torch.Tensor, position_ids: torch.Tensor, labels: torch.Tensor
+    ):
+        return unpad_input(input_ids, attention_mask, position_ids, labels)
+
+    @torch.no_grad()
+    def pad_inputs(self, input_ids: torch.Tensor, attention_mask: torch.Tensor, labels: torch.Tensor):
+        return pad_input(input_ids, attention_mask, labels)
+
     def forward(
         self,
         input_ids: Optional[torch.Tensor],
@@ -957,6 +1023,11 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
         position_ids: Optional[torch.Tensor] = None,
         labels: Optional[torch.Tensor] = None,
         return_dict: Optional[bool] = None,
+        indices: Optional[torch.Tensor] = None,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[int] = None,
+        batch_size: Optional[int] = None,
+        seq_len: Optional[int] = None,
         **kwargs,
     ) -> Union[Tuple[torch.Tensor], MaskedLMOutput]:
         # labels should be a `torch.LongTensor` of shape
@@ -973,30 +1044,73 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        output = self.bert(input_ids, attention_mask=attention_mask, position_ids=position_ids)
+        if self.unpad_embeddings and (indices is None or cu_seqlens is None or max_seqlen is None):
+            batch_size, seq_len = input_ids.shape[:2]
+            input_ids, indices, cu_seqlens, max_seqlen, position_ids, labels = self.unpad_inputs(
+                input_ids, attention_mask, position_ids, labels
+            )
+
+        output = self.bert(
+            input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            indices=indices,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
 
         logits = self.decoder(self.head(output))
         loss = None
         if labels is not None:
             if self.return_z_loss:
                 loss, z_loss = self.loss_fn(logits.view(-1, logits.shape[-1]), labels.view(-1))
-                return MaskedLMOutputZLoss(
-                    loss=loss,
-                    ce_loss=loss - z_loss,
-                    z_loss=z_loss,
-                    logits=logits,
-                    hidden_states=None,
-                    attentions=None,
-                )
+                if self.pad_logits:
+                    return MaskedLMOutputZLoss(
+                        loss=loss,
+                        ce_loss=loss.detach().clone() - z_loss,
+                        z_loss=z_loss,
+                        logits=self.pad_inputs(logits, indices, batch_size, seq_len),
+                        hidden_states=None,
+                        attentions=None,
+                    )
+                else:
+                    return MaskedLMOutputZLoss(
+                        loss=loss,
+                        ce_loss=loss.detach().clone() - z_loss,
+                        z_loss=z_loss,
+                        logits=logits,
+                        hidden_states=None,
+                        attentions=None,
+                        indices=indices,
+                        cu_seqlens=cu_seqlens,
+                        max_seqlen=max_seqlen,
+                        batch_size=batch_size,
+                        seq_len=seq_len,
+                        labels=labels,
+                    )
             else:
                 loss = self.loss_fn(logits.view(-1, logits.shape[-1]), labels.view(-1))
 
-        return MaskedLMOutput(
-            loss=loss,
-            logits=logits,
-            hidden_states=None,
-            attentions=None,
-        )
+        if self.pad_logits:
+            return MaskedLMOutput(
+                loss=loss,
+                logits=self.pad_inputs(logits, indices, batch_size, seq_len),
+                hidden_states=None,
+                attentions=None,
+            )
+        else:
+            return MaskedLMOutput(
+                loss=loss,
+                logits=logits,
+                hidden_states=None,
+                attentions=None,
+                indices=indices,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                labels=labels,
+            )
 
     def prepare_inputs_for_generation(self, input_ids: torch.Tensor, attention_mask: torch.Tensor, **model_kwargs):
         input_shape = input_ids.shape

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -1013,8 +1013,18 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
         return unpad_input(input_ids, attention_mask, position_ids, labels)
 
     @torch.no_grad()
-    def pad_inputs(self, input_ids: torch.Tensor, attention_mask: torch.Tensor, labels: torch.Tensor):
-        return pad_input(input_ids, attention_mask, labels)
+    def pad_inputs(
+        self,
+        inputs: torch.Tensor,
+        indices: torch.Tensor,
+        batch_size: int,
+        seqlen: int,
+        labels: Optional[torch.Tensor] = None,
+        ignore_index: int = -100,
+    ):
+        return pad_input(
+            inputs=inputs, indices=indices, batch=batch_size, seqlen=seqlen, labels=labels, ignore_index=ignore_index
+        )
 
     def forward(
         self,
@@ -1069,7 +1079,7 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
                         loss=loss,
                         ce_loss=loss.detach().clone() - z_loss,
                         z_loss=z_loss,
-                        logits=self.pad_inputs(logits, indices, batch_size, seq_len),
+                        logits=self.pad_inputs(logits, indices, batch_size, seq_len)[0],
                         hidden_states=None,
                         attentions=None,
                     )
@@ -1094,7 +1104,7 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
         if self.pad_logits:
             return MaskedLMOutput(
                 loss=loss,
-                logits=self.pad_inputs(logits, indices, batch_size, seq_len),
+                logits=self.pad_inputs(logits, indices, batch_size, seq_len)[0],
                 hidden_states=None,
                 attentions=None,
             )

--- a/src/bert_layers/padding.py
+++ b/src/bert_layers/padding.py
@@ -1,0 +1,87 @@
+import torch
+from torch import Tensor
+from typing import Optional, Tuple
+import torch.nn.functional as F
+
+
+def unpad_input(
+    inputs: Tensor,
+    attention_mask: Tensor,
+    position_ids: Optional[Tensor] = None,
+    labels: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor, Tensor, int, Optional[Tensor], Optional[Tensor]]:
+    """
+    Remove padding from input sequences.
+
+    Args:
+        inputs: (batch, seqlen, ...) or (batch, seqlen)
+        attention_mask: (batch, seqlen), bool / int, 1 means valid and 0 means not valid.
+        position_ids: (batch, seqlen), int, position ids
+        labels: (batch, seqlen), int, labels
+
+    Returns:
+        unpadded_inputs: (total_nnz, ...), where total_nnz = number of tokens selected in attention_mask.
+        indices: (total_nnz)
+        cu_seqlens: (batch + 1), the cumulative sequence lengths
+        max_seqlen_in_batch: int
+        unpadded_position_ids: (total_nnz) or None
+        unpadded_labels: (total_nnz) or None
+    """
+    seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+    max_seqlen_in_batch = int(seqlens_in_batch.max().item())
+    cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+
+    if inputs.dim() == 2:
+        unpadded_inputs = inputs.flatten()[indices]
+    else:
+        batch, seqlen, *rest = inputs.shape
+        shape = batch * seqlen
+        unpadded_inputs = inputs.view(shape, *rest)[indices]
+
+    unpadded_position_ids = position_ids.flatten()[indices] if position_ids is not None else None
+    unpadded_labels = labels.flatten()[indices] if labels is not None else None
+
+    return unpadded_inputs, indices, cu_seqlens, max_seqlen_in_batch, unpadded_position_ids, unpadded_labels
+
+
+def pad_input(
+    inputs: Tensor,
+    indices: Tensor,
+    batch: int,
+    seqlen: int,
+    labels: Optional[Tensor] = None,
+    ignore_index: int = -100,
+) -> Tuple[Tensor, Optional[Tensor]]:
+    """
+    Add padding to sequences.
+
+    Args:
+        inputs: (total_nnz, ...) or (total_nnz,), where total_nnz = number of tokens selected in attention_mask.
+        indices: (total_nnz)
+        batch: int, batch size
+        seqlen: int, max sequence length
+        position_ids: (total_nnz) or None
+        labels: (total_nnz) or None
+
+    Returns:
+        padded_inputs: (batch, seqlen, ...) or (batch, seqlen)
+        padded_labels: (batch, seqlen) or None
+    """
+    if inputs.dim() == 1:
+        output = torch.zeros(batch * seqlen, dtype=inputs.dtype, device=inputs.device)
+        output[indices] = inputs
+        padded_inputs = output.view(batch, seqlen)
+    else:
+        _, *rest = inputs.shape
+        output = torch.zeros(batch * seqlen, *rest, dtype=inputs.dtype, device=inputs.device)
+        output[indices] = inputs
+        padded_inputs = output.view(batch, seqlen, *rest)
+
+    padded_labels = None
+    if labels is not None:
+        padded_labels = torch.full((batch * seqlen,), fill_value=ignore_index, dtype=labels.dtype, device=labels.device)
+        padded_labels[indices] = labels
+        padded_labels = padded_labels.view(batch, seqlen)
+
+    return padded_inputs, padded_labels

--- a/src/bert_layers/rotary.py
+++ b/src/bert_layers/rotary.py
@@ -292,3 +292,6 @@ class UnpaddedRotaryEmbedding(torch.nn.Module):
         )
 
         return qkv
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}, base={self.base}, scale_base={self.scale_base}"

--- a/src/flex_bert.py
+++ b/src/flex_bert.py
@@ -160,7 +160,7 @@ class EfficientHuggingFaceModel(HuggingFaceModel):
         elif isinstance(metric, EfficientCrossEntropy):
             metric_result = metric.update(outputs["loss"])
         else:
-            metric_result = metric.update(outputs["logits"], self.labels)
+            metric_result = metric.update(outputs["logits"], outputs.get("labels", self.labels))
 
         if metric_result is not None:
             # Add the metric name once for each datapoint in the batch

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,93 @@
+import torch
+import pytest
+import sys
+import os
+
+# Add tests folder root to path to allow us to use relative imports regardless of what directory the script is run from
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+# Add folder root to path to allow us to use relative imports regardless of what directory the script is run from
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from src.bert_layers.padding import unpad_input, pad_input
+
+
+@pytest.fixture
+def sample_data():
+    batch, seqlen, hidden_dim = 2, 4, 3
+    inputs = torch.randn(batch, seqlen, hidden_dim)
+    attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.int32)
+    position_ids = torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long)
+    labels = torch.tensor([[1, 2, 3, -100], [4, 5, -100, -100]], dtype=torch.long)
+    return inputs, attention_mask, position_ids, labels
+
+
+def test_unpad_input(sample_data):
+    inputs, attention_mask, position_ids, labels = sample_data
+    unpadded_inputs, indices, cu_seqlens, max_seqlen, unpadded_position_ids, unpadded_labels = unpad_input(
+        inputs, attention_mask, position_ids, labels
+    )
+
+    assert unpadded_inputs.shape == (5, 3)  # 5 valid tokens, hidden_dim = 3
+    assert indices.tolist() == [0, 1, 2, 4, 5]
+    assert cu_seqlens.tolist() == [0, 3, 5]
+    assert max_seqlen == 3
+    assert unpadded_position_ids.tolist() == [0, 1, 2, 0, 1]
+    assert unpadded_labels.tolist() == [1, 2, 3, 4, 5]
+
+
+def test_pad_input(sample_data):
+    inputs, attention_mask, _, labels = sample_data
+    unpadded_inputs, indices, _, _, _, unpadded_labels = unpad_input(inputs, attention_mask, labels=labels)
+
+    padded_inputs, padded_labels = pad_input(unpadded_inputs, indices, batch=2, seqlen=4, labels=unpadded_labels)
+
+    assert padded_inputs.shape == (2, 4, 3)
+    assert torch.allclose(padded_inputs[attention_mask.bool()], unpadded_inputs)
+    assert torch.all(padded_inputs[~attention_mask.bool()] == 0)
+    assert torch.all(padded_labels[attention_mask.bool()] == unpadded_labels)
+    assert torch.all(padded_labels[~attention_mask.bool()] == -100)
+
+
+def test_roundtrip(sample_data):
+    inputs, attention_mask, _, labels = sample_data
+    unpadded_inputs, indices, _, _, _, unpadded_labels = unpad_input(inputs, attention_mask, labels=labels)
+    padded_inputs, padded_labels = pad_input(unpadded_inputs, indices, batch=2, seqlen=4, labels=unpadded_labels)
+
+    assert torch.allclose(inputs[attention_mask.bool()], padded_inputs[attention_mask.bool()])
+    assert torch.all(labels == padded_labels)
+
+
+def test_token_input():
+    batch, seqlen, vocab_size = 2, 4, 1000
+    token_ids = torch.randint(0, vocab_size, (batch, seqlen))
+    attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.int32)
+
+    unpadded_inputs, indices, _, _, _, _ = unpad_input(token_ids, attention_mask)
+
+    assert unpadded_inputs.shape == (5,)  # 5 valid tokens
+    assert unpadded_inputs.dtype == torch.long
+
+    padded_inputs, _ = pad_input(unpadded_inputs, indices, batch=2, seqlen=4)
+
+    assert padded_inputs.shape == (2, 4)
+    assert padded_inputs.dtype == torch.long
+    assert torch.all(padded_inputs[attention_mask.bool()] == unpadded_inputs)
+    assert torch.all(padded_inputs[~attention_mask.bool()] == 0)
+
+
+def test_2d_input():
+    batch, seqlen = 2, 4
+    inputs = torch.randn(batch, seqlen)
+    attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.int32)
+
+    unpadded_inputs, indices, cu_seqlens, max_seqlen, _, _ = unpad_input(inputs, attention_mask)
+
+    assert unpadded_inputs.shape == (5,)  # 5 valid tokens
+    assert indices.tolist() == [0, 1, 2, 4, 5]
+    assert cu_seqlens.tolist() == [0, 3, 5]
+    assert max_seqlen == 3
+
+    padded_inputs, _ = pad_input(unpadded_inputs, indices, batch=2, seqlen=4)
+
+    assert padded_inputs.shape == (2, 4)
+    assert torch.allclose(padded_inputs[attention_mask.bool()], unpadded_inputs)
+    assert torch.all(padded_inputs[~attention_mask.bool()] == 0)

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -130,6 +130,8 @@ def test_trainer(
         # if sliding window is set, there might only be one attention layer with a sliding window
         if sliding_window:
             # fmt: off
+            if config.model.model_config.initial_attention_layer in ["rope", "rope_parallel"]:
+                config.model.model_config.local_attn_rotary_emb_base = random.choice([1000, -1])
             if config.model.model_config.global_attn_every_n_layers == 2:
                 assert model1.bert.encoder.layers[1].attn.sliding_window == (32, 32), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
             else:

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -42,6 +42,8 @@ layer_combinations = [
 @pytest.mark.parametrize("layer,embedding,attention,mlp", layer_combinations)
 @pytest.mark.parametrize("different_first_layer", [False, True])
 @pytest.mark.parametrize("sliding_window", [False, True])
+@pytest.mark.parametrize("unpad_embeddings", [False, True])
+# @pytest.mark.parametrize("pad_logits", [False, True])
 def test_trainer(
     padding: str,
     layer: str,
@@ -50,7 +52,16 @@ def test_trainer(
     mlp: str,
     different_first_layer: bool,
     sliding_window: bool,
+    unpad_embeddings: bool,
+    pad_logits: bool = False,
 ):
+    if padding == "padded" and (unpad_embeddings or pad_logits):
+        pytest.skip("Unpad embeddings requires the unpadded model path.")
+    if not unpad_embeddings and pad_logits:
+        pytest.skip("Pad logits requires unpadded embeddings.")
+    if unpad_embeddings and embedding == "absolute_pos":
+        pytest.skip("Unpadded embeddings are not compatible with absolute pos embeddings.")
+
     with open("yamls/defaults.yaml") as f:
         default_cfg = OmegaConf.load(f)
     with open("yamls/models/flex_bert.yaml") as f:
@@ -59,6 +70,7 @@ def test_trainer(
         test_config = OmegaConf.load(f)
     config = OmegaConf.merge(default_cfg, model_cfg, test_config)
     assert isinstance(config, DictConfig)
+
     config.model.name = "flex_bert"
     config.seed = 42
     config.model.model_config.padding = padding
@@ -102,6 +114,9 @@ def test_trainer(
             config.model.model_config.use_sdpa_attn_mask = True
         else:
             config.model.model_config.use_sdpa_attn_mask = False
+        if padding == "unpadded" and unpad_embeddings:
+            config.model.model_config.unpad_embeddings = True
+            config.model.model_config.pad_logits = pad_logits
         config.train_loader.dataset.remote = tmp_datadir
         config.train_loader.dataset.local = os.path.join(tmp_datadir, "tr-local1")
         config.eval_loader.dataset.remote = tmp_datadir

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -43,7 +43,7 @@ layer_combinations = [
 @pytest.mark.parametrize("different_first_layer", [False, True])
 @pytest.mark.parametrize("sliding_window", [False, True])
 @pytest.mark.parametrize("unpad_embeddings", [False, True])
-# @pytest.mark.parametrize("pad_logits", [False, True])
+@pytest.mark.parametrize("pad_logits", [False, True])
 def test_trainer(
     padding: str,
     layer: str,
@@ -53,7 +53,7 @@ def test_trainer(
     different_first_layer: bool,
     sliding_window: bool,
     unpad_embeddings: bool,
-    pad_logits: bool = False,
+    pad_logits: bool,
 ):
     if padding == "padded" and (unpad_embeddings or pad_logits):
         pytest.skip("Unpad embeddings requires the unpadded model path.")
@@ -136,6 +136,7 @@ def test_trainer(
                 assert model1.bert.encoder.layers[0].attn.sliding_window == (32, 32), f"Sliding window not set for first layer: {model1.bert.encoder.layers[0].attn}"
                 assert model1.bert.encoder.layers[1].attn.sliding_window == (32, 32), f"Sliding window not set for second layer: {model1.bert.encoder.layers[1].attn}"
                 assert model1.bert.encoder.layers[2].attn.sliding_window == (32, 32), f"Sliding window not set for third layer: {model1.bert.encoder.layers[2].attn}"
+            # fmt: on
         # SDPA doesn't have sliding window impleemnted, so skip the test
         else:
             config.model.model_config.use_fa2 = False

--- a/yamls/main/flex-bert-base-parallel.yaml
+++ b/yamls/main/flex-bert-base-parallel.yaml
@@ -47,17 +47,21 @@ model:
     normalization: rmsnorm
     padding: unpadded
     sparse_prediction: False
-    hidden_act: silu
-    init_method: default
+    hidden_act: gelu
+    init_method: full_megatron
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
+    deterministic_fa2: false
     initial_attention_layer: null
     initial_bert_layer: null
     initial_mlp_layer: null
-    num_initial_layers: 1
-    skip_first_prenorm: false
-    deterministic_fa2: false
+    num_initial_layers: 0
+    skip_first_prenorm: true
+    sliding_window: 128
+    global_attn_every_n_layers: 3
+    unpad_embeddings: true
+    pad_logits: false
 
 
 # Dataloaders

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -47,12 +47,21 @@ model:
     normalization: rmsnorm
     padding: unpadded
     sparse_prediction: false
-    hidden_act: silu
-    init_method: default
+    hidden_act: gelu
+    init_method: full_megatron
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
     deterministic_fa2: false
+    initial_attention_layer: null
+    initial_bert_layer: null
+    initial_mlp_layer: null
+    num_initial_layers: 0
+    skip_first_prenorm: true
+    sliding_window: 128
+    global_attn_every_n_layers: 3
+    unpad_embeddings: true
+    pad_logits: false
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-base.yaml
+++ b/yamls/main/flex-bert-rope-base.yaml
@@ -51,12 +51,21 @@ model:
     rotary_emb_base: 10000.0
     rotary_emb_scale_base: null
     rotary_emb_interleaved: false
-    hidden_act: silu
-    init_method: default
+    hidden_act: gelu
+    init_method: full_megatron
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
     deterministic_fa2: false
+    initial_attention_layer: null
+    initial_bert_layer: null
+    initial_mlp_layer: null
+    num_initial_layers: 0
+    skip_first_prenorm: true
+    sliding_window: 128
+    global_attn_every_n_layers: 3
+    unpad_embeddings: true
+    pad_logits: false
 
 # Dataloaders
 train_loader:

--- a/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
+++ b/yamls/main/flex-bert-rope-parallel-firstprenorm.yaml
@@ -51,17 +51,21 @@ model:
     rotary_emb_base: 10000.0
     rotary_emb_scale_base: null
     rotary_emb_interleaved: false
-    hidden_act: silu
-    init_method: default
+    hidden_act: gelu
+    init_method: full_megatron
     init_std: 0.02
     init_cutoff_factor: 2.0
     init_small_embedding: False
-    initial_attention_layer: rope
-    initial_bert_layer: prenorm
-    initial_mlp_layer: glu
-    num_initial_layers: 1
-    skip_first_prenorm: true
     deterministic_fa2: false
+    initial_attention_layer: null
+    initial_bert_layer: null
+    initial_mlp_layer: null
+    num_initial_layers: 0
+    skip_first_prenorm: true
+    sliding_window: 128
+    global_attn_every_n_layers: 3
+    unpad_embeddings: true
+    pad_logits: false
 
 # Dataloaders
 train_loader:

--- a/yamls/models/flex_bert.yaml
+++ b/yamls/models/flex_bert.yaml
@@ -37,3 +37,18 @@ model:
     pooling_type: mean
     use_fa2: True
     use_sdpa_attn_mask: False
+    init_method: default
+    init_std: 0.02
+    init_cutoff_factor: 2.0
+    init_small_embedding: False
+    initial_attention_layer: null
+    initial_bert_layer: null
+    initial_mlp_layer: null
+    num_initial_layers: 1
+    skip_first_prenorm: False
+    deterministic_fa2: False
+    sliding_window: -1
+    global_attn_every_n_layers: -1
+    unpad_embeddings: False
+    pad_logits: False
+

--- a/yamls/models/flex_bert.yaml
+++ b/yamls/models/flex_bert.yaml
@@ -49,6 +49,7 @@ model:
     deterministic_fa2: False
     sliding_window: -1
     global_attn_every_n_layers: -1
+    local_attn_rotary_emb_base: -1
     unpad_embeddings: False
     pad_logits: False
 


### PR DESCRIPTION
**Changes**

This PR adds support for different RoPE settings for local attention layers via the `local_attn_rotary_emb_base` and `local_attn_rotary_emb_dim` flags. It builds on #99, which should be merged first.

**Tests**

- [x] Is the new feature tested? (Not always necessary for all changes -- just adding to the checklist to keep track)
- [x] Have you ran all the tests?
- [x] Do the tests all pass?
