### PR TITLE
Add support for Gemma-2 style Tanh Softcapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ To setup a reproducible Conda environment, run the following commands:
 ```bash
 conda env create -f environment.yaml
 conda activate bert24
-pip install "flash_attn==2.5.8" --no-build-isolation
+pip install "flash_attn==2.6.3" --no-build-isolation
 # or download a precompiled wheel from https://github.com/Dao-AILab/flash-attention/releases/tag/v2.5.8
 # or limit the number of parallel compilation jobs
-# MAX_JOBS=8 pip install "flash_attn==2.5.8" --no-build-isolation
+# MAX_JOBS=8 pip install "flash_attn==2.6.3" --no-build-isolation
 ```
 
 ----

--- a/src/bert_layers/attention.py
+++ b/src/bert_layers/attention.py
@@ -296,6 +296,7 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
@@ -392,6 +393,7 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -402,6 +404,7 @@ class FlexBertUnpadAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -454,6 +457,7 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
@@ -542,6 +546,7 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -552,6 +557,7 @@ class FlexBertUnpadParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -605,6 +611,7 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
@@ -677,6 +684,7 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -685,6 +693,7 @@ class FlexBertPaddedAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
         else:
             qkv = qkv.view(bs, seqlen, 3, self.num_attention_heads, self.attn_head_size)
@@ -764,6 +773,7 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -855,6 +865,7 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -865,6 +876,7 @@ class FlexBertUnpadRopeAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -920,6 +932,7 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
@@ -1017,6 +1030,7 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -1025,6 +1039,7 @@ class FlexBertPaddedRopeAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
         else:
             qkv = self.rotary_emb(qkv, seqlen_offset=seqlen_offset, max_seqlen=None)
@@ -1102,6 +1117,7 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         # Warn if defaulting to pytorch because of import issues
         if not IMPL_USE_FLASH2 and self.use_fa2:
@@ -1186,6 +1202,7 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -1196,6 +1213,7 @@ class FlexBertUnpadRopeParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
             attn = attn.view(bs, dim)
         else:
@@ -1250,6 +1268,7 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
         if not IMPL_USE_FLASH2 and self.use_fa2:
             self.use_fa2 = False
 
@@ -1342,6 +1361,7 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -1350,6 +1370,7 @@ class FlexBertPaddedRopeParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
         else:
             qkv = self.rotary_emb(qkv, seqlen_offset=seqlen_offset, max_seqlen=None)
@@ -1397,6 +1418,7 @@ class FlexBertPaddedParallelAttention(FlexBertAttentionBase):
         self.use_fa2 = config.use_fa2
         self.deterministic_fa2 = config.deterministic_fa2
         self.use_sdpa_attn_mask = config.use_sdpa_attn_mask
+        self.softcap = config.attn_logit_softcap
 
         if config.global_attn_every_n_layers > 0:
             if config.sliding_window == -1:
@@ -1462,6 +1484,7 @@ class FlexBertPaddedParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
                 attn = attn.to(orig_dtype)  # type: ignore
             else:
@@ -1470,6 +1493,7 @@ class FlexBertPaddedParallelAttention(FlexBertAttentionBase):
                     dropout_p=self.p_dropout,
                     deterministic=self.deterministic_fa2,
                     window_size=self.sliding_window,
+                    softcap=self.softcap,
                 )
         else:
             qkv = qkv.view(bs, seqlen, 3, self.num_attention_heads, self.attn_head_size)

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -960,6 +960,7 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
         self.return_z_loss = config.loss_kwargs.get("return_z_loss", False)
         self.unpad_embeddings = config.unpad_embeddings
         self.pad_logits = config.pad_logits
+        self.final_logit_softcap = config.final_logit_softcap
 
         # Initialize weights and apply final processing
         self._init_weights()
@@ -1070,6 +1071,11 @@ class FlexBertForMaskedLM(BertPreTrainedModel):
         )
 
         logits = self.decoder(self.head(output))
+        if self.final_logit_softcap is not None:
+            logits = logits / self.final_logit_softcap
+            logits = torch.tanh(logits)
+            logits = logits * self.final_logit_softcap
+
         loss = None
         if labels is not None:
             if self.return_z_loss:

--- a/tests/test_sdpa_fa2.py
+++ b/tests/test_sdpa_fa2.py
@@ -81,10 +81,15 @@ def test_trainer(
     if layer == "postnorm":
         config.model.model_config.final_norm = False
 
+    # final_logit_softcap supports flash attention & sdpa
+    config.model.model_config.final_logit_softcap = random.choice([None, 50])
+
     if sliding_window:
         config.model.model_config.sliding_window = 64
         config.model.model_config.num_hidden_layers = 3
         config.model.model_config.global_attn_every_n_layers = random.choice([-1, 2])
+        # attn_logit_softcap only supports flash attention
+        config.model.model_config.attn_logit_softcap = random.choice([0, 30])
 
     if different_first_layer:
         if layer != "parallel_prenorm":


### PR DESCRIPTION
**Changes**

This PR adds supports for Gemma-2 style Tanh Softcapping via the two flags `attn_logit_softcap` and `final_logit_softcap`. It builds on PRs #99 and #100 which should be merged in first.

**Tests**


- [x] Is the new feature tested? (Not always necessary for all changes -- just adding to the checklist to keep track)
- [x] Have you ran all the tests?
- [x] Do the tests all pass?
