### PR TITLE
PyTorch 2.4 with dynamic shape DDP Compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ To setup a reproducible Conda environment, run the following commands:
 ```bash
 conda env create -f environment.yaml
 conda activate bert24
-pip install "flash_attn==2.5.8" --no-build-isolation
+pip install "flash_attn==2.6.3" --no-build-isolation
 # or download a precompiled wheel from https://github.com/Dao-AILab/flash-attention/releases/tag/v2.5.8
 # or limit the number of parallel compilation jobs
-# MAX_JOBS=8 pip install "flash_attn==2.5.8" --no-build-isolation
+# MAX_JOBS=8 pip install "flash_attn==2.6.3" --no-build-isolation
+pip install mosaicml==0.24.0
+# or if 0.24 hasn't been released yet, pip install git+https://github.com/mosaicml/composer.git
 ```
 
 ----

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,48 +9,54 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
-  - aiohttp=3.9.5=py311h459d7ec_0
+  - aiohappyeyeballs=2.3.5=pyhd8ed1ab_0
+  - aiohttp=3.10.3=py311h61187de_0
   - aiosignal=1.3.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.11=hd590300_1
+  - alsa-lib=1.2.12=h4ab18f5_0
   - antlr-python-runtime=4.9.3=pyhd8ed1ab_1
-  - anyio=4.3.0=pyhd8ed1ab_0
+  - anyio=4.4.0=pyhd8ed1ab_0
+  - aom=3.9.1=hac33072_0
   - appdirs=1.4.4=pyh9f0ad1d_0
-  - argcomplete=3.3.0=pyhd8ed1ab_0
+  - argcomplete=3.5.0=pyhd8ed1ab_0
   - arrow=1.3.0=pyhd8ed1ab_0
-  - attr=2.5.1=h166bdaf_1
-  - attrs=23.2.0=pyh71513ae_0
-  - aws-c-auth=0.7.20=h5f1c8d9_0
-  - aws-c-cal=0.6.12=h2ba76a8_0
-  - aws-c-common=0.9.17=h4ab18f5_0
-  - aws-c-compression=0.2.18=h36a0aea_4
-  - aws-c-event-stream=0.4.2=h161de36_10
-  - aws-c-http=0.8.1=h63f54a0_13
-  - aws-c-io=0.14.8=h96d4d28_0
-  - aws-c-mqtt=0.10.4=hcc7299c_2
-  - aws-c-s3=0.5.8=h10bd90f_3
-  - aws-c-sdkutils=0.1.16=h36a0aea_0
-  - aws-checksums=0.1.18=h36a0aea_4
-  - aws-crt-cpp=0.26.8=h02fd9b4_10
-  - aws-sdk-cpp=1.11.267=h51dfee4_8
-  - azure-core=1.30.1=pyhd8ed1ab_0
-  - azure-identity=1.16.0=pyhd8ed1ab_0
-  - azure-storage-blob=12.20.0=pyhd8ed1ab_0
-  - azure-storage-file-datalake=12.15.0=pyhd8ed1ab_0
+  - attrs=24.2.0=pyh71513ae_0
+  - aws-c-auth=0.7.25=hff137af_5
+  - aws-c-cal=0.7.3=h7970872_0
+  - aws-c-common=0.9.25=h4bc722e_0
+  - aws-c-compression=0.2.18=hc649ecc_8
+  - aws-c-event-stream=0.4.2=h04a40c0_20
+  - aws-c-http=0.8.7=he2d3600_3
+  - aws-c-io=0.14.18=h7d46f39_3
+  - aws-c-mqtt=0.10.4=h674cf7e_16
+  - aws-c-s3=0.6.4=h28a8003_7
+  - aws-c-sdkutils=0.1.19=hc649ecc_0
+  - aws-checksums=0.1.18=hc649ecc_8
+  - aws-crt-cpp=0.27.5=heec6497_6
+  - aws-sdk-cpp=1.11.379=he20dfa5_2
+  - azure-core=1.30.2=pyhd8ed1ab_0
+  - azure-core-cpp=1.13.0=h935415a_0
+  - azure-identity=1.17.1=pyhd8ed1ab_0
+  - azure-identity-cpp=1.8.0=hd126650_2
+  - azure-storage-blob=12.22.0=pyhd8ed1ab_0
+  - azure-storage-blobs-cpp=12.12.0=hd2e3451_0
+  - azure-storage-common-cpp=12.7.0=h10ac4d7_1
+  - azure-storage-file-datalake=12.16.0=pyhd8ed1ab_0
+  - azure-storage-files-datalake-cpp=12.11.0=h325d260_1
   - backoff=2.2.1=pyhd8ed1ab_0
-  - bcrypt=4.1.2=py311h46250e7_0
+  - bcrypt=4.2.0=py311hb3a8bbb_0
   - blas=1.0=mkl
-  - boto3=1.34.104=pyhd8ed1ab_0
-  - botocore=1.34.104=pyge310_1234567_0
+  - boto3=1.34.159=pyhd8ed1ab_0
+  - botocore=1.34.160=pyge310_1234567_0
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py311hb755f60_1
-  - bzip2=1.0.8=hd590300_5
-  - c-ares=1.28.1=hd590300_0
-  - ca-certificates=2024.2.2=hbcca054_0
-  - cachetools=5.3.3=pyhd8ed1ab_0
-  - cairo=1.18.0=h3faef2a_0
-  - certifi=2024.2.2=pyhd8ed1ab_0
-  - cffi=1.16.0=py311hb3a22ac_0
+  - bzip2=1.0.8=h4bc722e_7
+  - c-ares=1.33.0=ha66036c_0
+  - ca-certificates=2024.7.4=hbcca054_0
+  - cachetools=5.4.0=pyhd8ed1ab_0
+  - cairo=1.18.0=hebfffa5_3
+  - certifi=2024.7.4=pyhd8ed1ab_0
+  - cffi=1.17.0=py311ha8e6434_0
   - charset-normalizer=3.3.2=pyhd8ed1ab_0
   - circuitbreaker=1.4.0=pyhd8ed1ab_0
   - click=8.1.7=unix_pyh707e725_0
@@ -75,7 +81,7 @@ dependencies:
   - cuda-driver-dev=12.1.105=0
   - cuda-gdb=12.1.105=0
   - cuda-libraries=12.1.0=0
-  - cuda-libraries-dev=12.1.0=0
+  - cuda-libraries-dev=12.6.0=0
   - cuda-libraries-static=12.1.1=0
   - cuda-nsight=12.1.105=0
   - cuda-nsight-compute=12.1.1=0
@@ -95,21 +101,23 @@ dependencies:
   - cuda-runtime=12.1.0=0
   - cuda-sanitizer-api=12.1.105=0
   - cuda-toolkit=12.1.0=0
-  - cuda-tools=12.1.0=0
-  - cuda-version=12.4=h3060b56_3
-  - cuda-visual-tools=12.1.0=0
+  - cuda-tools=12.1.1=0
+  - cuda-version=12.6=h7480c83_3
+  - cuda-visual-tools=12.1.1=0
   - cycler=0.12.1=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
-  - datasets=2.19.1=py_0
+  - datasets=2.21.0=py_0
+  - dav1d=1.2.1=hd590300_0
   - dbus=1.13.6=h5008d03_3
   - dill=0.3.8=pyhd8ed1ab_0
   - docker-pycreds=0.4.0=py_0
+  - double-conversion=3.3.0=h59595ed_0
   - einops=0.8.0=pyhd8ed1ab_0
-  - exceptiongroup=1.2.0=pyhd8ed1ab_2
+  - exceptiongroup=1.2.2=pyhd8ed1ab_0
   - expat=2.6.2=h59595ed_0
-  - fastparquet=2024.2.0=py311h1f0f07a_0
-  - ffmpeg=4.3=hf484d3e_0
-  - filelock=3.14.0=pyhd8ed1ab_0
+  - fastparquet=2024.5.0=py311h18e1886_0
+  - ffmpeg=7.0.2=gpl_h0db5852_100
+  - filelock=3.15.4=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
@@ -117,74 +125,74 @@ dependencies:
   - fontconfig=2.14.2=h14ed4e7_0
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
-  - fonttools=4.51.0=py311h459d7ec_0
+  - fonttools=4.53.1=py311h61187de_0
   - freetype=2.12.1=h267a509_2
+  - fribidi=1.0.10=h36c2ea0_0
   - frozenlist=1.4.1=py311h459d7ec_0
-  - fsspec=2024.3.1=pyhca7485f_0
+  - fsspec=2024.6.1=pyhff2d567_0
   - gds-tools=1.6.1.9=0
-  - gettext=0.22.5=h59595ed_2
-  - gettext-tools=0.22.5=h59595ed_2
+  - gettext=0.22.5=he02047a_3
+  - gettext-tools=0.22.5=he02047a_3
   - gflags=2.2.2=he1b5a44_1004
   - gitdb=4.0.11=pyhd8ed1ab_0
   - gitpython=3.1.43=pyhd8ed1ab_0
-  - glib=2.80.2=hf974151_0
-  - glib-tools=2.80.2=hb6ce0ca_0
-  - glog=0.7.0=hed5481d_0
-  - gmp=6.3.0=h59595ed_1
+  - glog=0.7.1=hbabe93e_0
+  - gmp=6.3.0=hac33072_2
   - gmpy2=2.1.5=py311hc4f1f91_1
-  - gnutls=3.6.13=h85f3911_1
-  - google-api-core=2.19.0=pyhd8ed1ab_0
-  - google-auth=2.29.0=pyhca7485f_0
+  - gnutls=3.7.9=hb077bed_0
+  - google-api-core=2.19.1=pyhd8ed1ab_0
+  - google-auth=2.33.0=pyhff2d567_0
   - google-cloud-core=2.4.1=pyhd8ed1ab_0
   - google-cloud-storage=2.10.0=pyh1a96a4e_0
   - google-crc32c=1.1.2=py311h9b08b9c_5
-  - google-resumable-media=2.7.0=pyhd8ed1ab_0
-  - googleapis-common-protos=1.63.0=pyhd8ed1ab_0
+  - google-resumable-media=2.7.2=pyhd8ed1ab_1
+  - googleapis-common-protos=1.63.2=pyhd8ed1ab_0
   - gql=3.5.0=pyhd8ed1ab_1
   - graphite2=1.3.13=h59595ed_1003
   - graphql-core=3.2.3=pyhd8ed1ab_0
   - grpcio=1.62.2=py311ha6695c7_0
-  - gst-plugins-base=1.24.3=h9ad1361_0
-  - gstreamer=1.24.3=haf2f30d_0
-  - harfbuzz=8.5.0=hfac3d4d_0
-  - huggingface_hub=0.23.0=py_0
-  - icu=73.2=h59595ed_0
+  - h2=4.1.0=pyhd8ed1ab_0
+  - harfbuzz=9.0.0=hda332d3_1
+  - hpack=4.0.0=pyh9f0ad1d_0
+  - huggingface_hub=0.24.5=py_0
+  - hyperframe=6.0.1=pyhd8ed1ab_0
+  - icu=75.1=he02047a_0
   - idna=3.7=pyhd8ed1ab_0
   - importlib-metadata=6.10.0=pyha770c72_0
   - iniconfig=2.0.0=pyhd8ed1ab_0
-  - intel-openmp=2022.1.0=h9e868ea_3769
+  - intel-openmp=2022.0.1=h06a4308_3633
   - isodate=0.6.1=pyhd8ed1ab_0
   - jinja2=3.1.4=pyhd8ed1ab_0
   - jmespath=1.0.1=pyhd8ed1ab_0
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.5=py311h9547e67_1
-  - krb5=1.21.2=h659d440_0
+  - krb5=1.21.3=h659f571_0
   - lame=3.100=h166bdaf_1003
   - lcms2=2.16=hb7c19ff_0
-  - ld_impl_linux-64=2.40=h55db66e_0
+  - ld_impl_linux-64=2.40=hf3520f5_7
   - lerc=4.0.0=h27087fc_0
-  - libabseil=20240116.2=cxx17_h59595ed_0
-  - libarrow=16.0.0=hefa796f_1_cpu
-  - libarrow-acero=16.0.0=hac33072_1_cpu
-  - libarrow-dataset=16.0.0=hac33072_1_cpu
-  - libarrow-substrait=16.0.0=h7e0c224_1_cpu
-  - libasprintf=0.22.5=h661eb56_2
-  - libasprintf-devel=0.22.5=h661eb56_2
+  - libabseil=20240116.2=cxx17_he02047a_1
+  - libarrow=17.0.0=h03aeac6_7_cpu
+  - libarrow-acero=17.0.0=he02047a_7_cpu
+  - libarrow-dataset=17.0.0=he02047a_7_cpu
+  - libarrow-substrait=17.0.0=hc9a23c6_7_cpu
+  - libasprintf=0.22.5=he8f35ee_3
+  - libasprintf-devel=0.22.5=he8f35ee_3
+  - libass=0.17.3=h1dc1e6a_0
   - libblas=3.9.0=16_linux64_mkl
   - libbrotlicommon=1.1.0=hd590300_1
   - libbrotlidec=1.1.0=hd590300_1
   - libbrotlienc=1.1.0=hd590300_1
-  - libcap=2.69=h0f662aa_0
   - libcblas=3.9.0=16_linux64_mkl
-  - libclang-cpp15=15.0.7=default_h127d8a8_5
-  - libclang13=18.1.5=default_h5d6823c_0
+  - libclang-cpp18.1=18.1.8=default_hf981a13_2
+  - libclang13=18.1.8=default_h9def88c_2
   - libcrc32c=1.1.2=h9c3ff4c_0
   - libcublas=12.1.0.26=0
   - libcublas-dev=12.1.0.26=0
-  - libcublas-static=12.4.5.8=he02047a_2
+  - libcublas-static=12.6.0.22=he02047a_0
   - libcufft=11.0.2.4=0
   - libcufft-dev=11.0.2.4=0
-  - libcufft-static=11.2.1.3=he02047a_2
+  - libcufft-static=11.2.6.28=he02047a_0
   - libcufile=1.6.1.9=0
   - libcufile-dev=1.6.1.9=0
   - libcufile-static=1.6.1.9=0
@@ -192,238 +200,258 @@ dependencies:
   - libcurand=10.3.2.106=0
   - libcurand-dev=10.3.2.106=0
   - libcurand-static=10.3.2.106=0
-  - libcurl=8.7.1=hca28451_0
+  - libcurl=8.9.1=hdb1bdb2_0
   - libcusolver=11.4.4.55=0
   - libcusolver-dev=11.4.4.55=0
-  - libcusolver-static=11.6.1.9=he02047a_2
+  - libcusolver-static=11.6.4.38=he02047a_0
   - libcusparse=12.0.2.55=0
   - libcusparse-dev=12.0.2.55=0
-  - libcusparse-static=12.3.1.170=he02047a_2
-  - libdeflate=1.20=hd590300_0
+  - libcusparse-static=12.5.2.23=he02047a_0
+  - libdeflate=1.21=h4bc722e_0
+  - libdrm=2.4.122=h4ab18f5_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=hd590300_2
   - libevent=2.1.12=hf998b51_1
   - libexpat=2.6.2=h59595ed_0
   - libffi=3.4.2=h7f98852_5
-  - libflac=1.4.3=h59595ed_0
-  - libgcc-ng=13.2.0=h77fa898_7
-  - libgcrypt=1.10.3=hd590300_0
-  - libgettextpo=0.22.5=h59595ed_2
-  - libgettextpo-devel=0.22.5=h59595ed_2
+  - libgcc-ng=14.1.0=h77fa898_0
+  - libgcrypt=1.11.0=h4ab18f5_1
+  - libgettextpo=0.22.5=he02047a_3
+  - libgettextpo-devel=0.22.5=he02047a_3
   - libgirepository=1.80.1=h003a4f0_0
-  - libglib=2.80.2=hf974151_0
-  - libgomp=13.2.0=h77fa898_7
-  - libgoogle-cloud=2.23.0=h9be4e54_1
-  - libgoogle-cloud-storage=2.23.0=hc7a4891_1
-  - libgpg-error=1.49=h4f305b6_0
+  - libglib=2.80.3=h315aac3_2
+  - libgomp=14.1.0=h77fa898_0
+  - libgoogle-cloud=2.28.0=h26d7fe4_0
+  - libgoogle-cloud-storage=2.28.0=ha262f82_0
+  - libgpg-error=1.50=h4f305b6_0
   - libgrpc=1.62.2=h15f2491_0
+  - libhwloc=2.11.1=default_hecaa2ac_1000
   - libiconv=1.17=hd590300_2
+  - libidn2=2.3.7=hd590300_0
   - libjpeg-turbo=3.0.0=hd590300_1
   - liblapack=3.9.0=16_linux64_mkl
-  - libllvm15=15.0.7=hb3ce162_4
-  - libllvm18=18.1.5=hb77312f_0
+  - libllvm18=18.1.8=h8b73ec9_2
   - libnghttp2=1.58.0=h47da74e_1
   - libnpp=12.0.2.50=0
   - libnpp-dev=12.0.2.50=0
-  - libnpp-static=12.2.5.30=he02047a_2
+  - libnpp-static=12.3.1.23=he02047a_0
   - libnsl=2.0.1=hd590300_0
+  - libnvfatbin=12.6.20=he02047a_0
+  - libnvfatbin-dev=12.6.20=he02047a_0
   - libnvjitlink=12.1.105=0
   - libnvjitlink-dev=12.1.105=0
-  - libnvjitlink-static=12.4.127=he02047a_2
+  - libnvjitlink-static=12.6.20=he02047a_0
   - libnvjpeg=12.1.1.14=0
   - libnvjpeg-dev=12.1.1.14=0
-  - libnvjpeg-static=12.3.1.117=ha770c72_2
+  - libnvjpeg-static=12.3.3.23=ha770c72_0
   - libnvvm-samples=12.1.105=0
-  - libogg=1.3.4=h7f98852_1
+  - libopenvino=2024.3.0=h2da1b83_0
+  - libopenvino-auto-batch-plugin=2024.3.0=hb045406_0
+  - libopenvino-auto-plugin=2024.3.0=hb045406_0
+  - libopenvino-hetero-plugin=2024.3.0=h5c03a75_0
+  - libopenvino-intel-cpu-plugin=2024.3.0=h2da1b83_0
+  - libopenvino-intel-gpu-plugin=2024.3.0=h2da1b83_0
+  - libopenvino-intel-npu-plugin=2024.3.0=h2da1b83_0
+  - libopenvino-ir-frontend=2024.3.0=h5c03a75_0
+  - libopenvino-onnx-frontend=2024.3.0=h07e8aee_0
+  - libopenvino-paddle-frontend=2024.3.0=h07e8aee_0
+  - libopenvino-pytorch-frontend=2024.3.0=he02047a_0
+  - libopenvino-tensorflow-frontend=2024.3.0=h39126c6_0
+  - libopenvino-tensorflow-lite-frontend=2024.3.0=he02047a_0
   - libopus=1.3.1=h7f98852_1
-  - libparquet=16.0.0=h6a7eafb_1_cpu
+  - libparquet=17.0.0=haa1307c_7_cpu
+  - libpciaccess=0.18=hd590300_0
   - libpng=1.6.43=h2797004_0
-  - libpq=16.3=ha72fbe1_0
+  - libpq=16.4=h482b261_0
   - libprotobuf=4.25.3=h08a7969_0
   - libre2-11=2023.09.01=h5a48ba9_2
   - libsecret=0.18.8=h329b89f_2
-  - libsentencepiece=0.2.0=hb0b37bd_1
-  - libsndfile=1.2.2=hc60ed4a_1
+  - libsentencepiece=0.2.0=he81a138_2
   - libsodium=1.0.18=h36c2ea0_1
-  - libsqlite=3.45.3=h2797004_0
+  - libsqlite=3.46.0=hde9e2c9_0
   - libssh2=1.11.0=h0841786_0
-  - libstdcxx-ng=13.2.0=hc0a3c3a_7
-  - libsystemd0=255=h3516f8a_1
-  - libthrift=0.19.0=hb90f79a_1
-  - libtiff=4.6.0=h1dd3fc0_3
+  - libstdcxx-ng=14.1.0=hc0a3c3a_0
+  - libtasn1=4.19.0=h166bdaf_0
+  - libthrift=0.20.0=hb90f79a_0
+  - libtiff=4.6.0=h46a8edc_4
+  - libunistring=0.9.10=h7f98852_0
   - libutf8proc=2.8.0=h166bdaf_0
   - libuuid=2.38.1=h0b41bf4_0
-  - libvorbis=1.3.7=h9c3ff4c_0
+  - libva=2.22.0=hb711507_0
+  - libvpx=1.14.1=hac33072_0
   - libwebp-base=1.4.0=hd590300_0
-  - libxcb=1.15=h0b41bf4_0
+  - libxcb=1.16=hd590300_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxkbcommon=1.7.0=h662e7e4_0
-  - libxml2=2.12.7=hc051c1a_0
-  - libzlib=1.2.13=hd590300_5
-  - lightning-utilities=0.11.2=pyhd8ed1ab_0
+  - libxkbcommon=1.7.0=h2c5496b_1
+  - libxml2=2.12.7=he7c6b58_4
+  - libxslt=1.1.39=h76b75d6_0
+  - libzlib=1.3.1=h4ab18f5_1
+  - lightning-utilities=0.11.6=pyhd8ed1ab_0
   - llvm-openmp=15.0.7=h0cdce71_0
   - lz4-c=1.9.4=hcb278e6_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
   - markupsafe=2.1.5=py311h459d7ec_0
-  - matplotlib=3.8.4=py311h38be061_0
-  - matplotlib-base=3.8.4=py311h54ef318_0
+  - matplotlib=3.9.1=py311h38be061_2
+  - matplotlib-base=3.9.1=py311h74b4f7c_2
   - mdurl=0.1.2=pyhd8ed1ab_0
   - mkl=2022.1.0=hc2b9512_224
   - mpc=1.3.1=hfe3b2da_0
-  - mpfr=4.2.1=h9458935_1
-  - mpg123=1.32.6=h59595ed_0
+  - mpfr=4.2.1=h38ae2d0_2
   - mpmath=1.3.0=pyhd8ed1ab_0
-  - msal=1.28.0=pyhd8ed1ab_0
+  - msal=1.30.0=pyhd8ed1ab_0
   - msal_extensions=1.1.0=py311h38be061_1
   - multidict=6.0.5=py311h459d7ec_0
   - multiprocess=0.70.16=py311h459d7ec_0
   - munkres=1.1.4=pyh9f0ad1d_0
-  - mysql-common=8.3.0=hf1915f5_4
-  - mysql-libs=8.3.0=hca2cd23_4
+  - mysql-common=8.3.0=h70512c7_5
+  - mysql-libs=8.3.0=ha479ceb_5
   - ncurses=6.5=h59595ed_0
-  - nettle=3.6=he412f7d_0
+  - nettle=3.9.1=h7ab15ed_0
   - networkx=3.3=pyhd8ed1ab_1
+  - ninja=1.11.1=h924138e_0
   - nsight-compute=2023.1.1.4=0
-  - nspr=4.35=h27087fc_0
-  - nss=3.100=hca3bf56_0
   - numpy=1.26.4=py311h64a7726_0
-  - oci=2.126.3=pyhd8ed1ab_0
+  - oci=2.131.1=pyhd8ed1ab_0
+  - ocl-icd=2.3.2=hd590300_1
   - omegaconf=2.3.0=pyhd8ed1ab_0
-  - openh264=2.1.1=h780b84a_0
+  - openh264=2.4.1=h59595ed_0
   - openjpeg=2.5.2=h488ebb8_0
-  - openssl=3.3.0=hd590300_0
-  - orc=2.0.0=h17fec99_1
-  - packaging=24.0=pyhd8ed1ab_0
-  - pandas=2.2.2=py311h320fe9a_0
+  - openssl=3.3.1=h4bc722e_2
+  - orc=2.0.1=h17fec99_1
+  - p11-kit=0.24.1=hc5aa10d_0
+  - packaging=24.1=pyhd8ed1ab_0
+  - pandas=2.2.2=py311h14de704_1
   - paramiko=2.12.0=pyhd8ed1ab_0
   - pathtools=0.1.2=py_1
-  - pcre2=10.43=hcad00b1_0
-  - pillow=10.3.0=py311h18e6fac_0
-  - pip=24.0=pyhd8ed1ab_0
+  - pcre2=10.44=hba22ea6_2
+  - pillow=10.4.0=py311h82a398c_0
+  - pip=24.2=pyhd8ed1ab_0
   - pixman=0.43.2=h59595ed_0
   - pluggy=1.5.0=pyhd8ed1ab_0
-  - ply=3.11=pyhd8ed1ab_2
-  - portalocker=2.8.2=py311h38be061_1
+  - portalocker=2.10.1=py311h38be061_0
   - prompt-toolkit=3.0.36=pyha770c72_0
   - prompt_toolkit=3.0.36=hd8ed1ab_0
   - proto-plus=1.23.0=pyhd8ed1ab_0
   - protobuf=4.25.3=py311h7b78aeb_0
-  - psutil=5.9.8=py311h459d7ec_0
+  - psutil=6.0.0=py311h331c9d8_0
   - pthread-stubs=0.4=h36c2ea0_1001
-  - pulseaudio-client=17.0=hb77b528_0
+  - pugixml=1.14=h59595ed_0
   - py-cpuinfo=9.0.0=pyhd8ed1ab_0
-  - pyarrow=16.0.0=py311h781c19f_0
-  - pyarrow-core=16.0.0=py311h8e2c35d_0_cpu
+  - pyarrow=17.0.0=py311hbd00459_1
+  - pyarrow-core=17.0.0=py311h4510849_1_cpu
   - pyarrow-hotfix=0.6=pyhd8ed1ab_0
   - pyasn1=0.6.0=pyhd8ed1ab_0
   - pyasn1-modules=0.4.0=pyhd8ed1ab_0
-  - pycairo=1.26.0=py311h8feb60e_0
+  - pycairo=1.26.1=py311h64ab44a_0
   - pycparser=2.22=pyhd8ed1ab_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pygobject=3.48.2=py311h86ed371_0
-  - pyjwt=2.8.0=pyhd8ed1ab_1
+  - pyjwt=2.9.0=pyhd8ed1ab_1
   - pynacl=1.5.0=py311h459d7ec_3
-  - pynvml=11.5.0=pyhd8ed1ab_0
+  - pynvml=11.5.3=pyhd8ed1ab_0
   - pyopenssl=23.3.0=pyhd8ed1ab_0
   - pyparsing=3.1.2=pyhd8ed1ab_0
-  - pyqt=5.15.9=py311hf0fb5b6_5
-  - pyqt5-sip=12.12.2=py311hb755f60_5
+  - pyside6=6.7.2=py311hba19f1e_2
   - pysocks=1.7.1=pyha2e5f31_6
-  - pytest=8.2.0=pyhd8ed1ab_0
+  - pytest=8.3.2=pyhd8ed1ab_0
   - python=3.11.9=hb806964_0_cpython
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-tzdata=2024.1=pyhd8ed1ab_0
   - python-xxhash=3.4.1=py311h459d7ec_0
   - python_abi=3.11=4_cp311
-  - pytorch=2.3.0=py3.11_cuda12.1_cudnn8.9.2_0
+  - pytorch=2.4.0=py3.11_cuda12.1_cudnn9.1.0_0
   - pytorch-cuda=12.1=ha16c6d3_5
   - pytorch-mutex=1.0=cuda
   - pytorch-ranger=0.1.1=pyhd8ed1ab_0
   - pytz=2024.1=pyhd8ed1ab_0
   - pyu2f=0.1.5=pyhd8ed1ab_0
-  - pyyaml=6.0.1=py311h459d7ec_1
-  - qt-main=5.15.8=hc9dc06e_21
+  - pyyaml=6.0.2=py311h61187de_0
+  - qhull=2020.2=h434a139_5
+  - qt6-main=6.7.2=hb12f9c5_4
   - questionary=2.0.1=pyhd8ed1ab_1
   - re2=2023.09.01=h7f4b329_2
   - readline=8.2=h8228510_1
-  - regex=2024.5.10=py311h331c9d8_0
-  - requests=2.31.0=pyhd8ed1ab_0
+  - regex=2024.7.24=py311h61187de_0
+  - requests=2.32.3=pyhd8ed1ab_0
   - rich=13.7.1=pyhd8ed1ab_0
   - rsa=4.9=pyhd8ed1ab_0
   - ruamel.yaml=0.18.6=py311h459d7ec_0
   - ruamel.yaml.clib=0.2.8=py311h459d7ec_0
-  - s2n=1.4.13=he19d79f_0
-  - s3transfer=0.10.1=pyhd8ed1ab_0
-  - safetensors=0.4.3=py311h46250e7_0
-  - sentencepiece=0.2.0=h38be061_1
-  - sentencepiece-python=0.2.0=py311h99063f3_1
-  - sentencepiece-spm=0.2.0=hb0b37bd_1
-  - sentry-sdk=2.1.1=pyhd8ed1ab_0
+  - s2n=1.5.0=h3400bea_0
+  - s3transfer=0.10.2=pyhd8ed1ab_0
+  - safetensors=0.4.4=py311hb3a8bbb_0
+  - sentencepiece=0.2.0=h38be061_2
+  - sentencepiece-python=0.2.0=py311h7fa642f_2
+  - sentencepiece-spm=0.2.0=he81a138_2
+  - sentry-sdk=2.13.0=pyhd8ed1ab_0
   - setproctitle=1.3.3=py311h459d7ec_0
-  - setuptools=69.5.1=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - shellingham=1.5.4=pyhd8ed1ab_0
-  - sip=6.7.12=py311hb755f60_0
   - six=1.16.0=pyh6c4a22f_0
   - smmap=5.0.0=pyhd8ed1ab_0
-  - snappy=1.2.0=hdb0a2a9_1
+  - snappy=1.2.1=ha2e4443_0
   - sniffio=1.3.1=pyhd8ed1ab_0
-  - sympy=1.12=pypyh9d50eac_103
+  - svt-av1=2.1.2=hac33072_0
+  - sympy=1.13.2=pypyh2585a3b_103
   - tabulate=0.9.0=pyhd8ed1ab_1
+  - tbb=2021.12.0=h434a139_3
   - termcolor=2.4.0=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - tokenizers=0.19.1=py311h6640629_0
-  - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
   - torch-optimizer=0.3.0=pyhd8ed1ab_0
-  - torchmetrics=1.3.2=pyhd8ed1ab_0
-  - torchtriton=2.3.0=py311
-  - torchvision=0.18.0=py311_cu121
-  - tornado=6.4=py311h459d7ec_0
-  - tqdm=4.66.4=pyhd8ed1ab_0
-  - transformers=4.40.2=pyhd8ed1ab_0
+  - torchmetrics=1.4.0.post0=pyhd8ed1ab_0
+  - torchtriton=3.0.0=py311
+  - torchvision=0.19.0=py311_cu121
+  - tornado=6.4.1=py311h331c9d8_0
+  - tqdm=4.66.5=pyhd8ed1ab_0
+  - transformers=4.41.2=pyhd8ed1ab_0
   - typer=0.12.3=pyhd8ed1ab_0
   - typer-slim=0.12.3=pyhd8ed1ab_0
   - typer-slim-standard=0.12.3=hd8ed1ab_0
   - types-python-dateutil=2.9.0.20240316=pyhd8ed1ab_0
-  - typing-extensions=4.11.0=hd8ed1ab_0
-  - typing_extensions=4.11.0=pyha770c72_0
+  - typing-extensions=4.12.2=hd8ed1ab_0
+  - typing_extensions=4.12.2=pyha770c72_0
   - tzdata=2024a=h0c530f3_0
-  - urllib3=2.2.1=pyhd8ed1ab_0
-  - validators=0.28.1=pyhd8ed1ab_0
-  - wandb=0.16.5=pyhd8ed1ab_0
+  - urllib3=2.2.2=pyhd8ed1ab_1
+  - validators=0.33.0=pyhd8ed1ab_0
+  - wandb=0.16.6=pyhd8ed1ab_0
+  - wayland=1.23.0=h5291e77_0
+  - wayland-protocols=1.36=hd8ed1ab_0
   - wcwidth=0.2.13=pyhd8ed1ab_0
   - websockets=11.0.3=py311h459d7ec_1
-  - wheel=0.43.0=pyhd8ed1ab_1
-  - xcb-util=0.4.0=hd590300_1
-  - xcb-util-image=0.4.0=h8ee46fc_1
-  - xcb-util-keysyms=0.4.0=h8ee46fc_1
-  - xcb-util-renderutil=0.3.9=hd590300_1
-  - xcb-util-wm=0.4.1=h8ee46fc_1
-  - xkeyboard-config=2.41=hd590300_0
+  - wheel=0.44.0=pyhd8ed1ab_0
+  - x264=1!164.3095=h166bdaf_2
+  - x265=3.5=h924138e_3
+  - xcb-util=0.4.1=hb711507_2
+  - xcb-util-cursor=0.1.4=h4ab18f5_2
+  - xcb-util-image=0.4.0=hb711507_2
+  - xcb-util-keysyms=0.4.1=hb711507_0
+  - xcb-util-renderutil=0.3.10=hb711507_0
+  - xcb-util-wm=0.4.2=hb711507_0
+  - xkeyboard-config=2.42=h4ab18f5_0
+  - xorg-fixesproto=5.0=h7f98852_1002
   - xorg-kbproto=1.0.7=h7f98852_1002
   - xorg-libice=1.1.1=hd590300_0
   - xorg-libsm=1.2.4=h7391055_0
-  - xorg-libx11=1.8.9=h8ee46fc_0
+  - xorg-libx11=1.8.9=hb711507_1
   - xorg-libxau=1.0.11=hd590300_0
   - xorg-libxdmcp=1.1.3=h7f98852_0
   - xorg-libxext=1.3.4=h0b41bf4_2
+  - xorg-libxfixes=5.0.3=h7f98852_1004
   - xorg-libxrender=0.9.11=hd590300_0
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h0b41bf4_1003
-  - xorg-xf86vidmodeproto=2.3.1=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
   - xxhash=0.8.2=hd590300_0
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
   - yarl=1.9.4=py311h459d7ec_0
-  - zipp=3.17.0=pyhd8ed1ab_0
-  - zlib=1.2.13=hd590300_5
+  - zipp=3.20.0=pyhd8ed1ab_0
+  - zlib=1.3.1=h4ab18f5_1
+  - zstandard=0.23.0=py311h5cd10c7_0
   - pip:
-      - composer==0.22.0
-      - evaluate==0.4.2
-      - mosaicml-cli==0.6.24
-      - mosaicml-streaming==0.7.6
-      - ninja==1.11.1.1
-      - python-snappy==0.7.1
-      - scikit-learn==1.5.0
+      - mosaicml-streaming==0.8.0
+      - python-snappy==0.7.2
+      - torch-optimi==0.2.1
       - zstd==1.5.5.1

--- a/src/bert_layers/configuration_bert.py
+++ b/src/bert_layers/configuration_bert.py
@@ -95,6 +95,7 @@ class FlexBertConfig(TransformersBertConfig):
         local_attn_rotary_emb_dim: int | None = None,
         unpad_embeddings: bool = False,
         pad_logits: bool = False,
+        compile_model: bool = True,
         **kwargs,
     ):
         """
@@ -152,6 +153,7 @@ class FlexBertConfig(TransformersBertConfig):
             local_attn_rotary_emb_dim (int | None): Rotary embedding dimension for local attention. None to disable and use `rotary_emb_dim` for all layers.
             unpad_embeddings (bool): Unpad inputs before the embedding layer.
             pad_logits (bool): Pad logits after the calculating the loss.
+            compile_model (bool): Compile the subset of the model which can be compiled.
             **kwargs: Additional keyword arguments.
         """
         super().__init__(attention_probs_dropout_prob=attention_probs_dropout_prob, **kwargs)
@@ -207,6 +209,7 @@ class FlexBertConfig(TransformersBertConfig):
         self.local_attn_rotary_emb_dim = local_attn_rotary_emb_dim
         self.unpad_embeddings = unpad_embeddings
         self.pad_logits = pad_logits
+        self.compile_model = compile_model
 
         if loss_kwargs.get("return_z_loss", False):
             if loss_function != "fa_cross_entropy":

--- a/src/bert_layers/embeddings.py
+++ b/src/bert_layers/embeddings.py
@@ -158,6 +158,28 @@ class FlexBertAbsoluteEmbeddings(FlexBertEmbeddingsBase):
         return self.drop(embeddings)
 
 
+class FlexBertCompiledSansPositionEmbeddings(FlexBertEmbeddingsBase):
+    """Construct the embeddings from token embeddings without any positional embeddings."""
+
+    def __init__(self, config: FlexBertConfig):
+        super().__init__(config)
+        self.tok_embeddings = nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id)
+
+        self.norm = get_norm_layer(config, compiled_norm=config.compile_model) if config.embed_norm else nn.Identity()
+        self.drop = nn.Dropout(config.embed_dropout_prob) if config.embed_dropout_prob > 0.0 else nn.Identity()
+
+    def _init_weights(self, reset_params: bool = False):
+        init_weights(self.config, self.tok_embeddings, type_of_module=ModuleType.emb)
+
+        if reset_params:
+            if self.config.embed_norm:
+                self.norm.reset_parameters()  # type: ignore
+
+    @torch.compile(dynamic=True)
+    def forward(self, input_ids: torch.LongTensor, position_ids: Optional[torch.LongTensor] = None) -> torch.Tensor:
+        return self.drop(self.norm(self.tok_embeddings(input_ids)))
+
+
 class FlexBertSansPositionEmbeddings(FlexBertEmbeddingsBase):
     """Construct the embeddings from token embeddings without any positional embeddings."""
 
@@ -187,6 +209,10 @@ EBB2CLS = {
 
 def get_embedding_layer(config: FlexBertConfig) -> FlexBertEmbeddingsBase:
     try:
+        if config.compile_model and config.embedding_layer == "sans_pos":
+            return FlexBertCompiledSansPositionEmbeddings(config)
+        elif config.compile_model:
+            raise ValueError(f"{config.compile_model=} only supports sans_pos embeddings.")
         return EBB2CLS[config.embedding_layer](config)
     except KeyError:
         raise ValueError(f"Invalid embeddings layer type: {config.embedding_layer=}, must be one of {EBB2CLS.keys()}.")

--- a/src/bert_layers/mlp.py
+++ b/src/bert_layers/mlp.py
@@ -16,7 +16,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from .configuration_bert import FlexBertConfig, maybe_add_padding
+from .configuration_bert import FlexBertConfig
 from .activation import get_act_fn
 from .normalization import get_norm_layer
 from .initialization import ModuleType, init_weights

--- a/src/bert_layers/normalization.py
+++ b/src/bert_layers/normalization.py
@@ -5,19 +5,20 @@
 # License: LLAMA 2 COMMUNITY LICENSE AGREEMENT
 
 
-from typing import Optional
 import inspect
-import warnings
 import torch
 import torch.nn as nn
 from torch.nn import init
 
 from .configuration_bert import FlexBertConfig
+
 try:
     from flash_attn.ops.triton.layer_norm import RMSNorm as TritonRMSNorm
+    from flash_attn.ops.triton.layer_norm import layer_norm_fn
 
 except ImportError:
     TritonRMSNorm = None
+    layer_norm_fn = None
 
 
 class RMSNorm(nn.Module):
@@ -71,20 +72,45 @@ class RMSNorm(nn.Module):
         init.ones_(self.weight)
 
 
+if layer_norm_fn is not None:
+
+    class TritonLayerNorm(nn.LayerNorm):
+        def forward(self, x, residual=None, prenorm=False, residual_in_fp32=False):
+            return layer_norm_fn(
+                x,
+                self.weight,
+                self.bias,
+                residual=residual,
+                eps=self.eps,
+                prenorm=prenorm,
+                residual_in_fp32=residual_in_fp32,
+            )
+else:
+    TritonLayerNorm = None
+
 NORM2CLS = {
     "layernorm": nn.LayerNorm,
-    "rmsnorm": RMSNorm if TritonRMSNorm is None else TritonRMSNorm,
+    "triton_layernorm": TritonLayerNorm if TritonLayerNorm is not None else nn.LayerNorm,
+    "rmsnorm": RMSNorm,
+    "triton_rmsnorm": TritonRMSNorm if TritonRMSNorm is not None else RMSNorm,
 }
 
 
-def get_norm_layer(config: FlexBertConfig) -> nn.Module:
+def get_norm_layer(config: FlexBertConfig, compiled_norm: bool = False) -> nn.Module:
     try:
-        norm_class = NORM2CLS[config.normalization]
-        signature = inspect.signature(norm_class)
+        if compiled_norm:
+            # Use non-Triton norms when compiling
+            if config.normalization.startswith("triton_"):
+                norm = config.normalization.replace("triton_", "")
+            else:
+                norm = config.normalization
+        else:
+            norm = config.normalization
+        signature = inspect.signature(NORM2CLS[norm])
         if hasattr(config, "norm_kwargs"):
             norm_kwargs = {k: v for k, v in config.norm_kwargs.items() if k in signature.parameters}
         else:
             norm_kwargs = {}
-        return norm_class(config.hidden_size, **norm_kwargs)
+        return NORM2CLS[norm](config.hidden_size, **norm_kwargs)
     except KeyError:
         raise ValueError(f"Invalid normalization layer type: {config.normalization}, must be one of {NORM2CLS.keys()}.")


### PR DESCRIPTION
This PR upgrades PyTorch to 2.4 which enables `torch.compile` with dynamic shapes and DDP.

Flash attention kernels, such as RoPE, are not compliable, so this PR compiles the FFN and head, and uses Flash Attention's Triton LayerNorm kernel when not compiled.

This increases single GPU training performance by ~11% on full batches. Multi-GPU with unpadded batches will likely be a bit lower.
