### PR TITLE
Add support for gradient norm logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ import src.hf_bert as hf_bert_module
 import src.mosaic_bert as mosaic_bert_module
 import src.text_data as text_data_module
 from src.callbacks.scheduled_gc import ScheduledGarbageCollector
+from src.callbacks.log_grad_norm import LogGradNorm
 from src.scheduler import CosineInverseSqrtScheduler, WarmupStableDecayScheduler
 
 
@@ -135,6 +136,8 @@ def build_callback(name, kwargs):
         )
     elif name == "scheduled_gc":
         return ScheduledGarbageCollector(batch_interval=kwargs.get("batch_interval", 10000))
+    elif name == "log_grad_norm":
+        return
     else:
         raise ValueError(f"Not sure how to build callback: {name}")
 
@@ -187,7 +190,10 @@ def build_optimizer(cfg, model):
         return AdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
     elif cfg.name == "stableadamw":
         try:
-            from optimi import StableAdamW
+            if cfg.log_grad_norm:
+                from src.optimizer import StableAdamW
+            else:
+                from optimi import StableAdamW
         except ImportError:
             raise ImportError("Install `pip install torch-optimi` to use the StableAdamW optimizer.")
 
@@ -198,7 +204,10 @@ def build_optimizer(cfg, model):
         return StableAdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
     elif cfg.name == "decoupled_stableadamw":
         try:
-            from optimi import StableAdamW
+            if cfg.log_grad_norm:
+                from src.optimizer import StableAdamW
+            else:
+                from optimi import StableAdamW
         except ImportError:
             raise ImportError("Install `pip install torch-optimi` to use the StableAdamW optimizer.")
 

--- a/main.py
+++ b/main.py
@@ -137,7 +137,10 @@ def build_callback(name, kwargs):
     elif name == "scheduled_gc":
         return ScheduledGarbageCollector(batch_interval=kwargs.get("batch_interval", 10000))
     elif name == "log_grad_norm":
-        return
+        return LogGradNorm(
+            log_optimizer_metrics=kwargs.get("log_optimizer_metrics", True),
+            batch_log_interval=kwargs.get("batch_log_interval", 10),
+        )
     else:
         raise ValueError(f"Not sure how to build callback: {name}")
 
@@ -190,7 +193,7 @@ def build_optimizer(cfg, model):
         return AdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
     elif cfg.name == "stableadamw":
         try:
-            if cfg.log_grad_norm:
+            if cfg.get("log_grad_norm", False):
                 from src.optimizer import StableAdamW
             else:
                 from optimi import StableAdamW
@@ -204,7 +207,7 @@ def build_optimizer(cfg, model):
         return StableAdamW(params, lr=cfg.lr, betas=list(cfg.betas), eps=cfg.eps, weight_decay=cfg.weight_decay)
     elif cfg.name == "decoupled_stableadamw":
         try:
-            if cfg.log_grad_norm:
+            if cfg.get("log_grad_norm", False):
                 from src.optimizer import StableAdamW
             else:
                 from optimi import StableAdamW

--- a/src/callbacks/log_grad_norm.py
+++ b/src/callbacks/log_grad_norm.py
@@ -44,8 +44,8 @@ class LogGradNorm(Callback):
         optimizer_metrics = getattr(state.optimizers[0], "grad_norms", None)
         if optimizer_metrics is not None:
             logged_metrics = {}
-            for metric in optimizer_metrics:
-                logged_metrics = {}
-                if isinstance(optimizer_metrics[metric], torch.Tensor):
-                    logged_metrics[f"gradient_norms/{metric}"] = optimizer_metrics[metric].item()
+            for metric, value in optimizer_metrics.items():
+                if isinstance(value, torch.Tensor):
+                    value = value.item()
+                logged_metrics[f"gradient_norms/{metric}"] = value
             logger.log_metrics(logged_metrics)

--- a/src/callbacks/log_grad_norm.py
+++ b/src/callbacks/log_grad_norm.py
@@ -1,0 +1,51 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Monitor gradients during training."""
+
+import logging
+import torch
+
+from composer.core import Callback, State
+from composer.loggers import Logger
+from composer.utils import dist
+
+try:
+    from src.optimizer import StableAdamW
+except ImportError:
+    StableAdamW = None
+
+__all__ = ["LogGradNorm"]
+
+
+log = logging.getLogger(__name__)
+
+
+class LogGradNorm(Callback):
+    """Logs the precomputed L1 and L2 gradient norms from StableAdamW"""
+
+    def __init__(self, log_optimizer_metrics: bool = True, batch_log_interval: int = 10):
+        self.log_optimizer_metrics = log_optimizer_metrics
+        self.batch_log_interval = batch_log_interval
+        if StableAdamW is None:
+            raise ImportError("Install `pip install torch-optimi` to use the StableAdamW optimizer.")
+
+    def epoch_start(self, state: State, logger: Logger):
+        if state.fsdp_enabled and dist.get_world_size() > 0 and self.log_optimizer_metrics:
+            raise ValueError("Logging grad_norms is currently incompatible with FSDP.")
+        if not isinstance(state.optimizers[0], StableAdamW):
+            self.log_optimizer_metrics = False
+            log.warn("Disabling `LogGradNorm` as it requires the internal `StableAdamW` optimizer")
+
+    def batch_end(self, state: State, logger: Logger):
+        if state.timestamp.batch.value % self.batch_log_interval != 0 or not self.log_optimizer_metrics:
+            return
+
+        optimizer_metrics = getattr(state.optimizers[0], "grad_norms", None)
+        if optimizer_metrics is not None:
+            logged_metrics = {}
+            for metric in optimizer_metrics:
+                logged_metrics = {}
+                if isinstance(optimizer_metrics[metric], torch.Tensor):
+                    logged_metrics[f"gradient_norms/{metric}"] = optimizer_metrics[metric].item()
+            logger.log_metrics(logged_metrics)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -1,0 +1,337 @@
+# Modified from https://github.com/warner-benjamin/optimi
+
+# Copyright (c) 2023 Benjamin Warner
+# SPDX-License-Identifier: MIT
+
+# Based on PyTorch Optimizers
+# PyTorch - PyTorch BSD-style license - Copyright (c) 2013-present PyTorch contributors
+
+# Kahan summation inspired by Torch Distributed Experimental's `AnyPrecisionAdamW`
+# torchdistX - BSD 3-Clause License - Copyright (c) Meta Platforms, Inc. and affiliates
+
+# Learning rate decoupled weight decay inspired by Composer's `DecoupledSGDW` & `DecoupledAdamW`
+# Composer - Apache License 2.0 - Copyright (c) 2022 MosaicML Composer authors
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+import torch
+from torch import Tensor
+from torch.optim.optimizer import _default_to_fused_or_foreach
+from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
+
+from optimi.optimizer import OptimiOptimizer
+from optimi.utils import debias_beta
+
+__all__ = ["StableAdamW", "stableadamw"]
+
+
+class StableAdamW(OptimiOptimizer):
+    """StableAdamW optimizer. An AdamW-Adafactor hybrid with learning rate update clipping.
+
+    This version is modified to only run foreach which has the option to return the model's l1 and l2 grad norm.
+    This only works because the bert24 model is being trained with DDP and the gradients are synced across all devices.
+    If trained with FSDP, then this will not work.
+
+    Args:
+        params: Iterable of parameters to optimize or dicts defining parameter groups
+        lr: Learning rate
+        betas: Coefficients for gradient and squared gradient moving averages (default: (0.9, 0.99))
+        weight_decay: Weight decay coefficient. If `decouple_lr` is False, applies decoupled weight
+            decay (default: 1e-2)
+        eps: Added to denominator to improve numerical stability (default: 1e-6)
+        decouple_lr: Apply fully decoupled weight decay instead of decoupled weight decay
+            (default: False)
+        max_lr: Maximum scheduled learning rate. Set if `lr` is not the maximum scheduled learning
+            rate and `decouple_lr` is True (default: None)
+        kahan_sum: Enables Kahan summation for more accurate parameter updates when training in low
+            precision (float16 or bfloat16). If unspecified, automatically applies for low precision
+            parameters (default: None)
+    """
+
+    def __init__(
+        self,
+        params: Iterable[Tensor] | Iterable[dict],
+        lr: float,
+        betas: tuple[float, float] = (0.9, 0.99),
+        weight_decay: float = 1e-2,
+        eps: float = 1e-6,
+        decouple_lr: bool = False,
+        max_lr: float | None = None,
+        kahan_sum: bool | None = None,
+        return_norms: bool = True,
+    ):
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError(f"Invalid beta1 parameter: {betas[0]=}")
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError(f"Invalid beta2 parameter: {betas[1]=}")
+        if not 0.0 <= eps:
+            raise ValueError(f"Invalid epsilon: {eps=}")
+
+        defaults = dict(
+            lr=lr,
+            beta1=betas[0],
+            beta2=betas[1],
+            eps=eps,
+            weight_decay=weight_decay,
+            decouple_lr=decouple_lr,
+            max_lr=max_lr,
+            kahan_sum=kahan_sum,
+            foreach=True,
+            gradient_release=False,
+            setup=False,
+        )
+        super().__init__(params, defaults)
+        self.return_norms = return_norms
+        self.grad_norms = {}
+
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor):
+        if "kahan_comp" not in state:
+            state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+            state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+            state["eps_sq"] = torch.tensor(group["eps"] ** 2, dtype=param.dtype, device=param.device)
+
+            if (group["kahan_sum"] or group["kahan_sum"] is None) and param.dtype in [torch.float16, torch.bfloat16]:
+                state["kahan_comp"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                group["kahan_sum"] = True
+            else:
+                state["kahan_comp"] = None
+
+            if group["gradient_release"]:
+                state["step"] = torch.tensor(0, dtype=torch.int32)
+
+    def _init_group(
+        self,
+        group: dict[str, Any],
+        params: list[Tensor],
+        grads: list[Tensor],
+        exp_avgs: list[Tensor],
+        exp_avg_sqs: list[Tensor],
+        eps_sqs: list[Tensor],
+        kahan_comps: list[Tensor],
+    ):
+        for p in group["params"]:
+            if p.grad is None:
+                continue
+
+            params.append(p)
+            grads.append(p.grad)
+            state = self.state[p]
+
+            self._init_state(group, state, p)
+
+            exp_avgs.append(state["exp_avg"])
+            exp_avg_sqs.append(state["exp_avg_sq"])
+            eps_sqs.append(state["eps_sq"])
+            kahan_comps.append(state["kahan_comp"])
+
+        if not group["setup"]:
+            group["setup"] = True
+            group["step"] = torch.tensor(0, dtype=torch.int32)
+
+            if group["foreach"] is None:
+                _, group["foreach"] = _default_to_fused_or_foreach(params, False, False)
+                if not group["foreach"]:
+                    raise ValueError("Foreach is required for this version supporting returning the gradnorm.")
+
+    @torch.no_grad()
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
+
+        Args:
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
+        """
+        loss = None
+        if closure is not None and param is None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps = [], [], [], [], [], []
+            self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps)
+
+            l1_norm, l2_norm = stableadamw(
+                params=params,
+                grads=grads,
+                exp_avgs=exp_avgs,
+                exp_avg_sqs=exp_avg_sqs,
+                eps_sqs=eps_sqs,
+                kahan_comps=kahan_comps,
+                lr=group["lr"],
+                beta1=group["beta1"],
+                beta2=group["beta2"],
+                weight_decay=group["weight_decay"],
+                eps=group["eps"],
+                step=group["step"],
+                decouple_lr=group["decouple_lr"],
+                max_lr=group["max_lr"],
+                kahan_sum=group["kahan_sum"],
+                return_norms=self.return_norms,
+            )
+
+        self.grad_norms["l1_norm"] = l1_norm
+        self.grad_norms["l2_norm"] = l2_norm
+
+        return loss
+
+
+def stableadamw(
+    params: list[Tensor],
+    grads: list[Tensor],
+    exp_avgs: list[Tensor],
+    exp_avg_sqs: list[Tensor],
+    eps_sqs: list[Tensor],
+    kahan_comps: list[Tensor | None] | None = None,
+    *,
+    lr: float,
+    beta1: float,
+    beta2: float,
+    weight_decay: float,
+    eps: float,
+    step: Tensor,
+    decouple_lr: bool = False,
+    max_lr: float | None = None,
+    kahan_sum: bool = False,
+    return_norms: bool = True,
+):
+    """Functional API to apply a StableAdamW optimization step.
+
+    See `optimi.StableAdamW` for more details.
+
+    Args:
+        params: Parameters to update
+        grads: Parameter gradients
+        exp_avgs: Gradient moving averages
+        exp_avg_sqs: Squared gradient moving averages
+        eps_sqs: Squared epsilon term tensors
+        kahan_comps: Kahan summation compensations
+        lr: Learning rate
+        beta1: Gradient moving average coefficient
+        beta2: Squared gradient moving average coefficient
+        weight_decay: Weight decay coefficient
+        eps: Added to denominator to improve numerical stability
+        step: Step counter used for bias correction
+        decouple_lr: Apply fully decoupled weight decay
+        max_lr: Maximum scheduled learning rate for `decouple_lr`
+        kahan_sum: Enables Kahan summation for low precision parameters
+    """
+    # calculate debiased beta hat & complement terms
+    step.add_(1)
+    beta1_comp = 1 - debias_beta(beta1, step.item())
+    beta2_hat = debias_beta(beta2, step.item())
+
+    if kahan_comps is None:
+        kahan_comps = [None] * len(params)
+
+    return _foreach_stableadamw(
+        params,
+        grads,
+        exp_avgs,
+        exp_avg_sqs,
+        eps_sqs,
+        kahan_comps,
+        lr=lr,
+        beta1_comp=beta1_comp,
+        beta2_hat=beta2_hat,
+        weight_decay=weight_decay,
+        eps=eps,
+        decouple_lr=decouple_lr,
+        max_lr=max_lr,
+        kahan_sum=kahan_sum,
+        return_norms=return_norms,
+    )
+
+
+def _foreach_stableadamw(
+    params: list[Tensor],
+    grads: list[Tensor],
+    exp_avgs: list[Tensor],
+    exp_avg_sqs: list[Tensor],
+    eps_sqs: list[Tensor],
+    kahan_comps: list[Tensor | None],
+    *,
+    lr: float,
+    beta1_comp: float,
+    beta2_hat: float,
+    weight_decay: float,
+    eps: float,
+    decouple_lr: bool,
+    max_lr: float | None = None,
+    kahan_sum: bool = False,
+    return_norms: bool = True,
+    **kwargs,
+):
+    if return_norms:
+        l1_norms = []
+        l2_norms = []
+
+    grouped_tensors = _group_tensors_by_device_and_dtype([params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps])
+    for (_, dtype), (
+        (dev_params, dev_grads, dev_exp_avgs, dev_exp_avg_sqs, dev_eps_sqs, dev_kahan_comps),
+        _,
+    ) in grouped_tensors.items():
+        do_kahan_sum = kahan_sum and dtype in [torch.float16, torch.bfloat16]
+
+        if return_norms:
+            l1_norms.extend(torch._foreach_norm(dev_grads, 1))
+            l2_norms.extend(torch._foreach_norm(dev_grads, 2))
+
+        # update gradient moving averages with debiased betas
+        torch._foreach_lerp_(dev_exp_avgs, dev_grads, weight=beta1_comp)
+        torch._foreach_mul_(dev_exp_avg_sqs, scalar=beta2_hat)
+        torch._foreach_addcmul_(dev_exp_avg_sqs, dev_grads, dev_grads, value=1 - beta2_hat)
+
+        # compute per parameter stabilization terms using dev_grads as temp buffer
+        max_exp_avg_sqs = torch._foreach_maximum(dev_exp_avg_sqs, other=dev_eps_sqs)
+        torch._foreach_pow_(dev_grads, exponent=2)
+        torch._foreach_div_(dev_grads, max_exp_avg_sqs)
+
+        # delete local intermediates to potentially save memory
+        del max_exp_avg_sqs
+
+        # calculate RMS stabilized learning rates and optionally weight decay
+        if weight_decay != 0:
+            neg_lrs, new_wds = [], []
+            for r in dev_grads:
+                neg_lrs.append(-lr / max(1, r.mean().sqrt().item()))
+                if decouple_lr:
+                    new_wds.append(1 + (neg_lrs[-1] / max_lr) * weight_decay)
+                else:
+                    new_wds.append(1 + neg_lrs[-1] * weight_decay)
+
+            # decoupled weight decay or fully decoupled weight decay
+            torch._foreach_mul_(dev_params, scalars=new_wds)
+        else:
+            neg_lrs = [-lr / max(1, r.mean().sqrt().item()) for r in dev_grads]
+
+        # Adam denominator using dev_grads as a temp buffer
+        torch._foreach_copy_(dev_grads, dev_exp_avg_sqs)
+        torch._foreach_sqrt_(dev_grads)
+        torch._foreach_add_(dev_grads, eps)
+
+        if do_kahan_sum:
+            # Adam step
+            torch._foreach_addcdiv_(dev_kahan_comps, dev_exp_avgs, dev_grads, scalars=neg_lrs)
+
+            # update weights with kahan compensation using dev_grads as temp buffer
+            torch._foreach_copy_(dev_grads, dev_params)
+            torch._foreach_add_(dev_params, dev_kahan_comps, alpha=1)
+
+            # save error back to kahan compensation for next iteration
+            torch._foreach_sub_(dev_grads, dev_params, alpha=1)
+            torch._foreach_add_(dev_kahan_comps, dev_grads, alpha=1)
+        else:
+            # Adam step
+            torch._foreach_addcdiv_(dev_params, dev_exp_avgs, dev_grads, scalars=neg_lrs)
+
+    if return_norms:
+        l1_norm = torch.linalg.vector_norm(torch.stack(l1_norms), 1)
+        l2_norm = torch.linalg.vector_norm(torch.stack(l2_norms), 2)
+        return l1_norm, l2_norm
+    else:
+        return None, None


### PR DESCRIPTION
This PR adds support for logging the L1 and L2 gradient norms into StableAdamW, following the PyToch `clip_grad_norm_` calculation method. It appears to slow down training by 1% at most.