### PR TITLE
Update installation instruction to change conda channel_priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Below, you'll temporarily find the original repository's README.md to help get y
 To setup a reproducible Conda environment, run the following commands:
 
 ```bash
+conda config --set channel_priority flexible
 conda env create -f environment.yaml
 conda activate bert24
 # if using H100s clone and build flash attention 3

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Below, you'll temporarily find the original repository's README.md to help get y
 To setup a reproducible Conda environment, run the following commands:
 
 ```bash
-conda config --set channel_priority flexible
 conda env create -f environment.yaml
+# if the conda environment errors out set channel priority to flexible:
+# conda config --set channel_priority flexible
 conda activate bert24
 # if using H100s clone and build flash attention 3
 # git clone https://github.com/Dao-AILab/flash-attention.git


### PR DESCRIPTION
**Changes**
Installation instructions were failing for me with the following error:
```
  - package cuda-nvcc_linux-64-12.4.99-h8a487aa_0 is excluded by strict repo priority
  - package cuda-cudart-dev_linux-64-12.4.99-h59595ed_0 is excluded by strict repo priority
  - package cuda-cudart-static_linux-64-12.4.99-h59595ed_0 is excluded by strict repo priority
  - package cuda-cudart_linux-64-12.4.99-h59595ed_0 is excluded by strict repo priority
  - package transformers-4.44.1-pyhd8ed1ab_0 is excluded by strict repo priority
  - package lcms2-2.16-hb7c19ff_0 requires libjpeg-turbo >=3.0.0,<4.0a0, but none of the providers can be installed
  - package ffmpeg-7.0.1-lgpl_hfba72e2_2 is excluded by strict repo priority
  - package python_abi-3.11-5_cp311 is excluded by strict repo priority
  - package cuda-crt-tools-12.4.99-ha770c72_1 is excluded by strict repo priority
  - package cuda-cupti-dev-12.4.99-h59595ed_1 is excluded by strict repo priority
  - package cuda-nvcc-impl-12.4.99-hd3aeb46_1 is excluded by strict repo priority
  - package cuda-nvcc-tools-12.4.99-hd3aeb46_1 is excluded by strict repo priority
  - package cuda-nvvm-impl-12.4.99-h59595ed_1 is excluded by strict repo priority
  - package cuda-nvvm-tools-12.4.99-h59595ed_1 is excluded by strict repo priority
  - package libnvfatbin-static-12.4.127-h7934f7d_2 is excluded by strict repo priority
  - package libnvjitlink-static-12.4.127-h99ab3db_1 is excluded by strict repo priority
  - package cuda-cccl_linux-64-12.4.99-ha770c72_1 is excluded by strict repo priority
  - package cuda-crt-dev_linux-64-12.4.99-ha770c72_1 is excluded by strict repo priority
  - package cuda-driver-dev_linux-64-12.4.127-hd681fbe_0 is excluded by strict repo priority
  - package cuda-nvcc-dev_linux-64-12.4.99-ha770c72_1 is excluded by strict repo priority
  - package cuda-nvvm-dev_linux-64-12.4.99-ha770c72_1 is excluded by strict repo priority
  - package cuda-version-12.4-hbda6634_3 is excluded by strict repo priority
  - package safetensors-0.4.4-py39hb0933c6_0 is excluded by strict repo priority
  - package tokenizers-0.19.1-py39hff361bb_0 is excluded by strict repo priority
```

Changing the conda channel_priority from strict to flexible fixed the issue for me.

**Tests**
Environment installation succeeds after change.
