### PR TITLE
Initialize model from Checkpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,6 @@ from composer.optim.scheduler import (
 )
 from composer.utils import dist, reproducibility
 from composer.utils.checkpoint import _ensure_valid_checkpoint
-from composer.utils.misc import partial_format
 from omegaconf import DictConfig, OmegaConf
 from omegaconf import OmegaConf as om
 from torch.optim import AdamW
@@ -38,7 +37,6 @@ import src.hf_bert as hf_bert_module
 import src.mosaic_bert as mosaic_bert_module
 import src.text_data as text_data_module
 from src.callbacks.dataloader_speed import DataloaderSpeedMonitor
-from src.callbacks.debug import DebugCallback
 from src.callbacks.log_grad_norm import LogGradNorm
 from src.callbacks.packing_efficiency import PackingEfficency
 from src.callbacks.scheduled_gc import ScheduledGarbageCollector
@@ -156,8 +154,6 @@ def build_callback(name, kwargs):
         return DataloaderSpeedMonitor()
     elif name == "packing_efficiency":
         return PackingEfficency(log_interval=kwargs.get("log_interval", 10))
-    elif name == "debug":
-        return DebugCallback()
     else:
         raise ValueError(f"Not sure how to build callback: {name}")
 

--- a/main.py
+++ b/main.py
@@ -338,8 +338,6 @@ def init_from_checkpoint(cfg: DictConfig, new_model: nn.Module):
         pretrained_model=pretrained_model.model,
         new_model=new_model.model,
         mode=cfg.get("mode", "tile_weights_from_middle"),
-        skip_norms=cfg.get("skip_norms", False),
-        clamp_weights=cfg.get("clamp_weights", None),
     )
     print(f"Initalized model from checkpoint {cfg.checkpoint_run_name} with {n_params=:.4e} parameters")
 

--- a/src/bert_layers/initialization.py
+++ b/src/bert_layers/initialization.py
@@ -15,7 +15,9 @@ import torch
 import torch.nn as nn
 
 from src.utils import StrEnum
+
 from .configuration_bert import FlexBertConfig
+from .normalization import RMSNorm
 
 __all__ = ["init_weights", "ModuleType", "InitFnType"]
 
@@ -159,3 +161,419 @@ def init_weights(
 
     if isinstance(module, nn.Embedding) and config.init_small_embedding:
         nn.init.uniform_(module.weight, a=-1e-4, b=1e-4)
+
+
+class TileMode(StrEnum):
+    center_weights = "center_weights"
+    tile_weights_from_edge = "tile_weights_from_edge"
+    tile_weights_from_middle = "tile_weights_from_middle"
+
+
+def tile_weight(
+    pretrained_weights: torch.Tensor,
+    new_weights: torch.Tensor,
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+    clamp_weights: Optional[float] = None,
+) -> torch.Tensor:
+    """
+    Tile or center an input tensor to a larger desired size. Works for both 2D and 1D tensors.
+
+    Args:
+    pretrained_weights (torch.Tensor): The input tensor to be tiled or centered (1D or 2D).
+    new_weights (torch.Tensor): The tensor with the desired size.
+    mode (Union[str, TileMode]): 'center_weights', 'tile_weights_from_edge', or 'tile_weights_from_middle'
+
+    Returns:
+    torch.Tensor: The resulting tensor of the desired size.
+    """
+    assert pretrained_weights.dim() in (1, 2), "Input tensor must be 1-dimensional or 2-dimensional"
+    if isinstance(mode, str):
+        mode = TileMode(mode)
+
+    pretrained_weights = pretrained_weights.clone()
+
+    if pretrained_weights.dim() == 1:
+        return _tile_1d(pretrained_weights, new_weights, mode, clamp_weights)
+    else:
+        return _tile_2d(pretrained_weights, new_weights, mode, clamp_weights)
+
+
+def _tile_1d(
+    pretrained_weights: torch.Tensor, new_weights: torch.Tensor, mode: TileMode, clamp_weights: Optional[float] = None
+) -> torch.Tensor:
+    assert pretrained_weights.dim() == 1, "Input tensor must be 1-dimensional"
+    input_size = pretrained_weights.shape[0]
+    new_size = new_weights.shape[0]
+    assert new_size >= input_size, "Desired size must be greater than or equal to input size"
+
+    if mode == TileMode.center_weights:
+        offset = (new_size - input_size) // 2
+        new_weights[offset : offset + input_size] = pretrained_weights
+        if clamp_weights is not None:
+            new_weights.clamp_(-clamp_weights, clamp_weights)
+        return new_weights.clone()
+    elif mode == TileMode.tile_weights_from_edge:
+        repeat_count = (new_size + input_size - 1) // input_size
+        tiled_tensor = pretrained_weights.repeat(repeat_count)
+        if clamp_weights is not None:
+            tiled_tensor.clamp_(-clamp_weights, clamp_weights)
+        return tiled_tensor[:new_size].clone()
+    elif mode == TileMode.tile_weights_from_middle:
+        # Calculate offsets to center the original tensor
+        offset = (new_size - input_size) // 2
+
+        # Create a new tensor with the desired size
+        result = torch.zeros(new_size, dtype=pretrained_weights.dtype, device=pretrained_weights.device)
+
+        # Place the original tensor in the center
+        result[offset : offset + input_size] = pretrained_weights
+
+        # Tile the left and right sides
+        for i in range(offset):
+            result[offset - 1 - i] = pretrained_weights[input_size - 1 - (i % input_size)]
+        for i in range(offset + input_size, new_size):
+            result[i] = pretrained_weights[(i - offset) % input_size]
+        if clamp_weights is not None:
+            result.clamp_(-clamp_weights, clamp_weights)
+        return result.clone()
+
+
+def _tile_2d(
+    pretrained_weights: torch.Tensor, new_weights: torch.Tensor, mode: TileMode, clamp_weights: Optional[float] = None
+) -> torch.Tensor:
+    assert pretrained_weights.dim() == 2, "Input tensor must be 2-dimensional"
+    input_height, input_width = pretrained_weights.shape
+    new_height, new_width = new_weights.shape
+    assert new_height >= input_height, "Desired height must be greater than or equal to input height"
+    assert new_width >= input_width, "Desired width must be greater than or equal to input width"
+
+    if mode == TileMode.center_weights:
+        height_offset = (new_height - input_height) // 2
+        width_offset = (new_width - input_width) // 2
+        new_weights[height_offset : height_offset + input_height, width_offset : width_offset + input_width] = pretrained_weights  # fmt: skip
+        if clamp_weights is not None:
+            new_weights.clamp_(-clamp_weights, clamp_weights)
+        return new_weights.clone()
+    elif mode == TileMode.tile_weights_from_edge:
+        repeat_height = (new_height + input_height - 1) // input_height
+        repeat_width = (new_width + input_width - 1) // input_width
+        tiled_tensor = pretrained_weights.repeat(repeat_height, repeat_width)
+        if clamp_weights is not None:
+            tiled_tensor.clamp_(-clamp_weights, clamp_weights)
+        return tiled_tensor[:new_height, :new_width].clone()
+    elif mode == TileMode.tile_weights_from_middle:
+        # Calculate offsets to center the original tensor
+        height_offset = (new_height - input_height) // 2
+        width_offset = (new_width - input_width) // 2
+
+        # Create a new tensor with the desired width and input height
+        horizontal_tiled = torch.zeros(
+            input_height, new_width, dtype=pretrained_weights.dtype, device=pretrained_weights.device
+        )
+
+        # Place the original tensor in the center horizontally
+        horizontal_tiled[:, width_offset : width_offset + input_width] = pretrained_weights
+
+        # Tile the left and right sides
+        for i in range(width_offset):
+            horizontal_tiled[:, i] = horizontal_tiled[
+                :, width_offset + input_width - 1 - (width_offset - i - 1) % input_width
+            ]
+        for i in range(width_offset + input_width, new_width):
+            horizontal_tiled[:, i] = horizontal_tiled[:, width_offset + (i - width_offset) % input_width]
+
+        # Now tile vertically
+        result = torch.zeros(new_height, new_width, dtype=pretrained_weights.dtype, device=pretrained_weights.device)
+        result[height_offset : height_offset + input_height, :] = horizontal_tiled
+
+        # Tile top
+        for i in range(height_offset):
+            row_to_copy = (input_height - 1) - (i % input_height)
+            result[height_offset - 1 - i, :] = horizontal_tiled[row_to_copy, :]
+
+        # Tile bottom
+        for i in range(height_offset + input_height, new_height):
+            row_to_copy = (i - height_offset) % input_height
+            result[i, :] = horizontal_tiled[row_to_copy, :]
+        if clamp_weights is not None:
+            result.clamp_(-clamp_weights, clamp_weights)
+        return result.clone()
+
+
+def tile_fused_qkv(
+    pretrained_qkv_weight: torch.Tensor,
+    new_qkv_weight: torch.Tensor,
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+    clamp_weights: Optional[float] = None,
+):
+    """
+    Tile the weights of a fused pretrained QKV layer to a new, larger QKV dimension.
+
+    Args:
+        pretrained_qkv_weight (torch.Tensor): The original fused QKV layer
+        new_qkv_weight (torch.Tensor): The new fused QKV layer with larger linear_dim
+        mode (Union[str, TileMode]): The tiling mode to use
+        clamp_weights (Optional[float]): The maximum/minimum value for the weights. If None, no clamping is done.
+    Returns:
+        torch.Tensor: The new fused QKV layer with tiled weights
+    """
+    # Split QKV, assume new_q, new_k, new_v are the same shape
+    pretrained_q, pretrained_k, pretrained_v = pretrained_qkv_weight.chunk(3, dim=0)
+    new_q, new_k, new_v = new_qkv_weight.chunk(3, dim=0)
+
+    # Tile Q, K, V separately
+    new_q = tile_weight(pretrained_q, new_q, mode=mode, clamp_weights=clamp_weights)
+    new_k = tile_weight(pretrained_k, new_k, mode=mode, clamp_weights=clamp_weights)
+    new_v = tile_weight(pretrained_v, new_v, mode=mode, clamp_weights=clamp_weights)
+
+    # Concatenate tiled Q, K, V
+    return torch.cat([new_q, new_k, new_v], dim=0)
+
+
+def tile_fused_glu(
+    pretrained_glu_weight: torch.Tensor,
+    new_glu_weight: torch.Tensor,
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+    clamp_weights: Optional[float] = None,
+):
+    """
+    Tile the weights of a fused pretrained GLU layer to a new, larger GLU dimension.
+
+    Args:
+        pretrained_glu_weight (torch.Tensor): The original fused GLU layer
+        new_glu_weight (torch.Tensor): The new fused GLU layer with larger linear_dim
+        mode (Union[str, TileMode]): The tiling mode to use
+        clamp_weights (Optional[float]): The maximum/minimum value for the weights. If None, no clamping is done.
+    Returns:
+        torch.Tensor: The new fused GLU layer with tiled weights
+    """
+    # Split GLU, assume new_glu_wi, new_glu_wg are the same shape
+    pretrained_glu_wi, pretrained_glu_wg = pretrained_glu_weight.chunk(2, dim=0)
+    new_glu_wi, new_glu_wg = new_glu_weight.chunk(2, dim=0)
+
+    # Tile GLU separately
+    new_glu_wi = tile_weight(pretrained_glu_wi, new_glu_wi, mode=mode, clamp_weights=clamp_weights)
+    new_glu_wg = tile_weight(pretrained_glu_wg, new_glu_wg, mode=mode, clamp_weights=clamp_weights)
+
+    # Concatenate tiled GLU
+    return torch.cat([new_glu_wi, new_glu_wg], dim=0)
+
+
+def tile_fused_qkvff(
+    pretrained_qkvff_weight: torch.Tensor,
+    new_qkvff_weight: torch.Tensor,
+    pretrained_attn_size: int,
+    pretrained_mlp_size: int,
+    new_attn_size: int,
+    new_mlp_size: int,
+    is_glu: bool = False,
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+    clamp_weights: Optional[float] = None,
+):
+    """
+    Tile the weights of a fused pretrained QKVFF layer to a new, larger QKVFF dimension.
+
+    Args:
+        pretrained_qkvff_weight (torch.Tensor): The original fused QKVFF layer
+        new_qkvff_weight (torch.Tensor): The new fused QKVFF layer with larger linear_dim
+        pretrained_attn_size (int): The attention size of the pretrained fused QKVFF layer
+        pretrained_mlp_size (int): The mlp size of the pretrained fused QKVFF layer
+        new_attn_size (int): The attention size of the new fused QKVFF layer
+        new_mlp_size (int): The mlp size of the new fused QKVFF layer
+        is_glu (bool): Whether the QKVFF layer is a GLU layer
+        mode (Union[str, TileMode]): The tiling mode to use
+        clamp_weights (Optional[float]): The maximum/minimum value for the weights. If None, no clamping is done.
+    Returns:
+        torch.Tensor: The new fused QKVFF layer with tiled weights
+    """
+    # Split QKVFF
+    pretrained_qkv, pretrained_ff = pretrained_qkvff_weight.split([pretrained_attn_size, pretrained_mlp_size], dim=0)
+    new_qkv, new_ff = new_qkvff_weight.split([new_attn_size, new_mlp_size], dim=0)
+
+    # Tile QKVFF separately
+    new_qkv = tile_fused_qkv(pretrained_qkv, new_qkv, mode=mode, clamp_weights=clamp_weights)
+    if is_glu:
+        new_ff = tile_fused_glu(pretrained_ff, new_ff, mode=mode, clamp_weights=clamp_weights)
+    else:
+        new_ff = tile_weight(pretrained_ff, new_ff, mode=mode, clamp_weights=clamp_weights)
+
+    # Concatenate tiled QKVFF
+    return torch.cat([new_qkv, new_ff], dim=0)
+
+
+class TileLinear(StrEnum):
+    wqkv = "wqkv"
+    glu = "glu"
+    wqkvff = "wqkvff"
+    default = "default"
+
+
+def tile_linear(
+    pretrained_linear: nn.Linear,
+    new_linear: nn.Linear,
+    linear_type: Union[str, TileLinear] = TileLinear.default,
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+    pretrained_attn_size: Optional[int] = None,
+    pretrained_mlp_size: Optional[int] = None,
+    new_attn_size: Optional[int] = None,
+    new_mlp_size: Optional[int] = None,
+    wqkvff_is_glu: Optional[bool] = None,
+    bias_only: Optional[bool] = False,
+    clamp_weights: Optional[float] = None,
+):
+    """
+    Tile the weights of a linear layer to a new, larger linear dimension.
+
+    Args:
+        pretrained_linear (nn.Linear): The original linear layer
+        new_linear (nn.Linear): The new linear layer with larger linear_dim
+        linear_type (Union[str, TileLinear]): The type of linear layer to tile
+        mode (Union[str, TileMode]): The tiling mode to use
+        pretrained_attn_size (int): The attention size of the pretrained linear layer. Only used if linear_type is wqkvff.
+        pretrained_mlp_size (int): The mlp size of the pretrained linear layer. Only used if linear_type is wqkvff.
+        new_attn_size (int): The attention size of the new linear layer. Only used if linear_type is wqkvff.
+        new_mlp_size (int): The mlp size of the new linear layer. Only used if linear_type is wqkvff.
+        wqkvff_is_glu (bool): Whether the wqkvff layer is a GLU layer. Only used if linear_type is wqkvff.
+        bias_only (bool): Whether to only tile the bias. Only used if tiling weight tied decoder.
+        clamp_weights (Optional[float]): The maximum/minimum value for the weights. If None, no clamping is done.
+    """
+    if isinstance(linear_type, str):
+        linear_type = TileLinear(linear_type)
+    if isinstance(mode, str):
+        mode = TileMode(mode)
+
+    with torch.no_grad():
+        if linear_type == TileLinear.wqkv:
+            if not bias_only:
+                new_linear.weight = nn.Parameter(
+                    tile_fused_qkv(pretrained_linear.weight, new_linear.weight, mode=mode, clamp_weights=clamp_weights),
+                    requires_grad=new_linear.weight.requires_grad,
+                )
+            if pretrained_linear.bias is not None:
+                new_linear.bias = nn.Parameter(
+                    tile_fused_qkv(pretrained_linear.bias, new_linear.bias, mode=mode, clamp_weights=clamp_weights),
+                    requires_grad=new_linear.bias.requires_grad,
+                )
+        elif linear_type == TileLinear.glu:
+            if not bias_only:
+                new_linear.weight = nn.Parameter(
+                    tile_fused_glu(pretrained_linear.weight, new_linear.weight, mode=mode, clamp_weights=clamp_weights),
+                    requires_grad=new_linear.weight.requires_grad,
+                )
+            if pretrained_linear.bias is not None:
+                new_linear.bias = nn.Parameter(
+                    tile_fused_glu(pretrained_linear.bias, new_linear.bias, mode=mode, clamp_weights=clamp_weights),
+                    requires_grad=new_linear.bias.requires_grad,
+                )
+        elif linear_type == TileLinear.wqkvff:
+            if not bias_only:
+                new_linear.weight = nn.Parameter(
+                    tile_fused_qkvff(
+                        pretrained_linear.weight,
+                        new_linear.weight,
+                        pretrained_attn_size,
+                        pretrained_mlp_size,
+                        new_attn_size,
+                        new_mlp_size,
+                        wqkvff_is_glu,
+                        mode=mode,
+                        clamp_weights=clamp_weights,
+                    ),
+                    requires_grad=new_linear.weight.requires_grad,
+                )
+            if pretrained_linear.bias is not None:
+                new_linear.bias = nn.Parameter(
+                    tile_fused_qkvff(
+                        pretrained_linear.bias,
+                        new_linear.bias,
+                        pretrained_attn_size,
+                        pretrained_mlp_size,
+                        new_attn_size,
+                        new_mlp_size,
+                        wqkvff_is_glu,
+                        mode=mode,
+                        clamp_weights=clamp_weights,
+                    ),
+                    requires_grad=new_linear.bias.requires_grad,
+                )
+        else:
+            if not bias_only:
+                new_linear.weight = nn.Parameter(
+                    tile_weight(pretrained_linear.weight, new_linear.weight, mode=mode, clamp_weights=clamp_weights),
+                    requires_grad=new_linear.weight.requires_grad,
+                )
+            if pretrained_linear.bias is not None:
+                new_linear.bias = nn.Parameter(
+                    tile_weight(pretrained_linear.bias, new_linear.bias, mode=mode, clamp_weights=clamp_weights),
+                    requires_grad=new_linear.bias.requires_grad,
+                )
+
+
+def tile_norm(
+    pretrained_norm: Union[nn.LayerNorm, RMSNorm, nn.Identity],
+    new_norm: Union[nn.LayerNorm, RMSNorm, nn.Identity],
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+):
+    """
+    Tile the weights of a pretrained norm layer to a new, larger layer norm dimension.
+
+    Args:
+        pretrained_norm (Union[nn.LayerNorm, RMSNorm, nn.Identity]): The original norm layer
+        new_norm (Union[nn.LayerNorm, RMSNorm, nn.Identity]): The new norm layer with larger layer norm dimension
+        mode (Union[str, TileMode]): The Phi-style weight tiling mode to use
+    """
+    if isinstance(pretrained_norm, nn.Identity):
+        return
+    if isinstance(mode, str):
+        mode = TileMode(mode)
+
+    with torch.no_grad():
+        new_norm.weight.data = nn.Parameter(
+            tile_weight(pretrained_norm.weight, new_norm.weight, mode=mode),
+            requires_grad=new_norm.weight.requires_grad,
+        )
+        if hasattr(pretrained_norm, "bias") and pretrained_norm.bias is not None:
+            new_norm.bias.data = nn.Parameter(
+                tile_weight(pretrained_norm.bias, new_norm.bias, mode=mode),
+                requires_grad=new_norm.bias.requires_grad,
+            )
+
+
+def tile_embedding(
+    pretrained_embedding: nn.Embedding,
+    new_embedding: nn.Embedding,
+    mode: Union[str, TileMode] = TileMode.tile_weights_from_middle,
+    clamp_weights: Optional[float] = None,
+) -> nn.Embedding:
+    """
+    Tile the weights of an embedding layer to a new, larger embedding dimension.
+
+    Args:
+    pretrained_embedding (nn.Embedding): The original embedding layer
+    new_embedding (nn.Embedding): The new embedding layer with larger embedding_dim
+    tile_mode (Union[str, TileMode]): The Phi-style weight tiling mode to use
+
+    Returns:
+    nn.Embedding: The new embedding layer with tiled weights
+    """
+    with torch.no_grad():
+        # Ensure vocabulary size remains the same
+        if pretrained_embedding.num_embeddings != new_embedding.num_embeddings:
+            raise ValueError("Vocabulary size (num_embeddings) must remain constant")
+
+        # Ensure new embedding dimension is larger
+        if new_embedding.embedding_dim <= pretrained_embedding.embedding_dim:
+            raise ValueError("New embedding_dim must be larger than the old embedding_dim")
+
+        # Tile the weights
+        new_embedding.weight.data = nn.Parameter(
+            tile_weight(pretrained_embedding.weight, new_embedding.weight, mode=mode, clamp_weights=clamp_weights),
+            requires_grad=new_embedding.weight.requires_grad,
+        )
+
+        # Handle padding_idx if it exists
+        if pretrained_embedding.padding_idx is not None:
+            if new_embedding.padding_idx is None:
+                new_embedding.padding_idx = pretrained_embedding.padding_idx
+            else:
+                assert new_embedding.padding_idx == pretrained_embedding.padding_idx, "padding_idx must remain the same"

--- a/src/bert_layers/model.py
+++ b/src/bert_layers/model.py
@@ -1586,11 +1586,11 @@ def init_model_from_pretrained(
 
         # First tile the normalization layers
         if hasattr(pretrained_layer, "attn_norm") and not skip_norms:
-            tile_norm(pretrained_layer.attn_norm, new_model_layer.attn_norm, mode=mode, clamp_weights=clamp_weights)
+            tile_norm(pretrained_layer.attn_norm, new_model_layer.attn_norm, mode=mode)
         if hasattr(pretrained_layer, "norm") and not skip_norms:
-            tile_norm(pretrained_layer.norm, new_model_layer.norm, mode=mode, clamp_weights=clamp_weights)
+            tile_norm(pretrained_layer.norm, new_model_layer.norm, mode=mode)
         if hasattr(pretrained_layer, "mlp_norm") and not skip_norms:
-            tile_norm(pretrained_layer.mlp_norm, new_model_layer.mlp_norm, mode=mode, clamp_weights=clamp_weights)
+            tile_norm(pretrained_layer.mlp_norm, new_model_layer.mlp_norm, mode=mode)
 
         # Then tile the attention & mlp layers
         assert isinstance(
@@ -1734,7 +1734,7 @@ def init_mlm_model_from_pretrained(
         clamp_weights=clamp_weights,
     )
     if not skip_norms:
-        tile_norm(pretrained_model.head.norm, new_model.head.norm, mode=mode, clamp_weights=clamp_weights)
+        tile_norm(pretrained_model.head.norm, new_model.head.norm, mode=mode)
 
     # setup weight tying
     if config.tie_word_embeddings:

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -1,0 +1,207 @@
+import os
+import sys
+
+import pytest
+import torch
+import torch.nn as nn
+
+# Add tests folder root to path to allow us to use relative imports regardless of what directory the script is run from
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+# Add folder root to path to allow us to use relative imports regardless of what directory the script is run from
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.bert_layers.initialization import tile_weight, tile_linear, TileMode
+
+
+tiling_test_data = [
+    # Test 1: 2x2 to 4x4
+    ((4, 4),
+     [[1, 2],
+      [3, 4]],
+     [[4, 3, 4, 3],
+      [2, 1, 2, 1],
+      [4, 3, 4, 3],
+      [2, 1, 2, 1]],
+     [[1, 2, 1, 2],
+      [3, 4, 3, 4],
+      [1, 2, 1, 2],
+      [3, 4, 3, 4]],
+     [[0, 0, 0, 0],
+      [0, 1, 2, 0],
+      [0, 3, 4, 0],
+      [0, 0, 0, 0]]),
+
+    # Test 2: 3x3 to 5x5
+    ((5, 5),
+     [[1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]],
+     [[9, 7, 8, 9, 7],
+      [3, 1, 2, 3, 1],
+      [6, 4, 5, 6, 4],
+      [9, 7, 8, 9, 7],
+      [3, 1, 2, 3, 1]],
+     [[1, 2, 3, 1, 2],
+      [4, 5, 6, 4, 5],
+      [7, 8, 9, 7, 8],
+      [1, 2, 3, 1, 2],
+      [4, 5, 6, 4, 5]],
+     [[0, 0, 0, 0, 0],
+      [0, 1, 2, 3, 0],
+      [0, 4, 5, 6, 0],
+      [0, 7, 8, 9, 0],
+      [0, 0, 0, 0, 0]]),
+
+    # Test 3: 2x3 to 6x7
+    ((6, 7),
+     [[1, 2, 3],
+      [4, 5, 6]],
+     [[2, 3, 1, 2, 3, 1, 2],
+      [5, 6, 4, 5, 6, 4, 5],
+      [2, 3, 1, 2, 3, 1, 2],
+      [5, 6, 4, 5, 6, 4, 5],
+      [2, 3, 1, 2, 3, 1, 2],
+      [5, 6, 4, 5, 6, 4, 5]],
+     [[1, 2, 3, 1, 2, 3, 1],
+      [4, 5, 6, 4, 5, 6, 4],
+      [1, 2, 3, 1, 2, 3, 1],
+      [4, 5, 6, 4, 5, 6, 4],
+      [1, 2, 3, 1, 2, 3, 1],
+      [4, 5, 6, 4, 5, 6, 4]],
+     [[0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 1, 2, 3, 0, 0],
+      [0, 0, 4, 5, 6, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0]]),
+
+    # Test 4: 4x2 to 7x5
+    ((7, 5),
+     [[1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8]],
+     [[8, 7, 8, 7, 8],
+      [2, 1, 2, 1, 2],
+      [4, 3, 4, 3, 4],
+      [6, 5, 6, 5, 6],
+      [8, 7, 8, 7, 8],
+      [2, 1, 2, 1, 2],
+      [4, 3, 4, 3, 4]],
+     [[1, 2, 1, 2, 1],
+      [3, 4, 3, 4, 3],
+      [5, 6, 5, 6, 5],
+      [7, 8, 7, 8, 7],
+      [1, 2, 1, 2, 1],
+      [3, 4, 3, 4, 3],
+      [5, 6, 5, 6, 5]],
+     [[0, 0, 0, 0, 0],
+      [0, 1, 2, 0, 0],
+      [0, 3, 4, 0, 0],
+      [0, 5, 6, 0, 0],
+      [0, 7, 8, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0]]),
+
+    # Test 5: 1x3 to 4x8
+    ((4, 8),
+     [[1, 2, 3]],
+     [[2, 3, 1, 2, 3, 1, 2, 3],
+      [2, 3, 1, 2, 3, 1, 2, 3],
+      [2, 3, 1, 2, 3, 1, 2, 3],
+      [2, 3, 1, 2, 3, 1, 2, 3]],
+     [[1, 2, 3, 1, 2, 3, 1, 2],
+      [1, 2, 3, 1, 2, 3, 1, 2],
+      [1, 2, 3, 1, 2, 3, 1, 2],
+      [1, 2, 3, 1, 2, 3, 1, 2]],
+     [[0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 1, 2, 3, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0]]),
+
+    # Test 6: 1D tensor - 3 to 8
+    ((8,),
+     [1, 2, 3],
+     [2, 3, 1, 2, 3, 1, 2, 3],
+     [1, 2, 3, 1, 2, 3, 1, 2],
+     [0, 0, 1, 2, 3, 0, 0, 0])
+]  # fmt: skip
+
+
+@pytest.mark.parametrize("new_size, input_tensor, expected_middle, expected_edge, expected_center", tiling_test_data)
+def test_tile_weight(new_size, input_tensor, expected_middle, expected_edge, expected_center):
+    input_tensor = torch.tensor(input_tensor)
+    expected_middle = torch.tensor(expected_middle)
+    expected_edge = torch.tensor(expected_edge)
+    expected_center = torch.tensor(expected_center)
+    output_tensor = torch.zeros(new_size)
+
+    # Test tiling from middle
+    result_middle = tile_weight(input_tensor, new_weights=output_tensor, mode=TileMode.tile_weights_from_middle)
+    assert torch.all(
+        result_middle.eq(expected_middle)
+    ), f"Middle tiling failed for input {input_tensor.tolist()} to size {new_size}"
+
+    # Test tiling from edge
+    result_edge = tile_weight(input_tensor, new_weights=output_tensor, mode=TileMode.tile_weights_from_edge)
+    assert torch.all(
+        result_edge.eq(expected_edge)
+    ), f"Edge tiling failed for input {input_tensor.tolist()} to size {new_size}"
+
+    # Test center only
+    result_center = tile_weight(input_tensor, new_weights=output_tensor, mode=TileMode.center_weights)
+    assert torch.all(
+        result_center.eq(expected_center)
+    ), f"Center only failed for input {input_tensor.tolist()} to size {new_size}"
+
+
+@pytest.mark.parametrize("new_size, input_tensor, expected_middle, expected_edge, expected_center", tiling_test_data)
+def test_tile_linear(new_size, input_tensor, expected_middle, expected_edge, expected_center):
+    input_tensor = torch.tensor(input_tensor, dtype=torch.float)
+    expected_middle = torch.tensor(expected_middle, dtype=torch.float)
+    expected_edge = torch.tensor(expected_edge, dtype=torch.float)
+    expected_center = torch.tensor(expected_center, dtype=torch.float)
+
+    if input_tensor.dim() == 1:
+        # Handle 1D tensor as bias
+        old_linear = nn.Linear(expected_middle.size(0), expected_middle.size(0), bias=True)
+        new_linear = nn.Linear(expected_middle.size(0), expected_middle.size(0), bias=True)
+        old_linear.bias = nn.Parameter(input_tensor)
+    else:
+        # Handle 2D tensor as weight
+        old_linear = nn.Linear(input_tensor.size(1), input_tensor.size(0), bias=False)
+        new_linear = nn.Linear(expected_middle.size(1), expected_middle.size(0), bias=False)
+        old_linear.weight = nn.Parameter(input_tensor)
+
+    # Test tiling from middle
+    if input_tensor.dim() == 1:
+        new_linear.bias = nn.Parameter(torch.zeros_like(expected_middle))
+        tile_linear(old_linear, new_linear, linear_type="default", mode=TileMode.tile_weights_from_middle)
+    else:
+        new_linear.weight = nn.Parameter(torch.zeros_like(expected_middle))
+        tile_linear(old_linear, new_linear, linear_type="default", mode=TileMode.tile_weights_from_middle)
+    assert torch.allclose(
+        new_linear.weight.data if input_tensor.dim() > 1 else new_linear.bias.data, expected_middle
+    ), "Middle tiling failed for Linear layer"
+
+    # Test tiling from edge
+    if input_tensor.dim() == 1:
+        new_linear.bias = nn.Parameter(torch.zeros_like(expected_edge))
+        tile_linear(old_linear, new_linear, linear_type="default", mode=TileMode.tile_weights_from_edge)
+    else:
+        new_linear.weight = nn.Parameter(torch.zeros_like(expected_edge))
+        tile_linear(old_linear, new_linear, linear_type="default", mode=TileMode.tile_weights_from_edge)
+    assert torch.allclose(
+        new_linear.weight.data if input_tensor.dim() > 1 else new_linear.bias.data, expected_edge
+    ), "Edge tiling failed for Linear layer"
+
+    # Test center only
+    if input_tensor.dim() == 1:
+        new_linear.bias = nn.Parameter(torch.zeros_like(expected_center))
+        tile_linear(old_linear, new_linear, linear_type="default", mode=TileMode.center_weights)
+    else:
+        new_linear.weight = nn.Parameter(torch.zeros_like(expected_center))
+        tile_linear(old_linear, new_linear, linear_type="default", mode=TileMode.center_weights)
+    assert torch.allclose(
+        new_linear.weight.data if input_tensor.dim() > 1 else new_linear.bias.data, expected_center
+    ), "Center only failed for Linear layer"


### PR DESCRIPTION
This PR adds support for initializing a new model, either the same size or larger, from an existing checkpoint.

It follows [Gopher](https://arxiv.org/abs/2112.11446) layer scaling to initialize deeper models from shallower models and provides an implementation of [Phi 1.5 & Phi 2's weight reuse](https://neurips.cc/media/neurips-2023/Slides/83968_5GxuY2z.pdf).

Tests show that when combined with a short amount of batch warmup, initializing model from a smaller pretrained checkpoint is a significant improvement over random initialization.