### PR TITLE
Add restart override flag to allow changing schedule, callbacks, and microbatch_size

### DIFF
--- a/main.py
+++ b/main.py
@@ -452,6 +452,7 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
     if do_train:
         print("Starting training...")
         if cfg.get("restart_override", False):
+            print("Overriding checkpoint's scheduler, callbacks, and train microbatch size with config options")
             trainer.fit(
                 schedulers=scheduler,
                 callbacks=callbacks,

--- a/main.py
+++ b/main.py
@@ -451,7 +451,14 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
 
     if do_train:
         print("Starting training...")
-        trainer.fit()
+        if cfg.get("restart_override", False):
+            trainer.fit(
+                schedulers=scheduler,
+                callbacks=callbacks,
+                device_train_microbatch_size=cfg.get("device_train_microbatch_size", "auto"),
+            )
+        else:
+            trainer.fit()
 
     if return_trainer:
         return trainer


### PR DESCRIPTION
This PR adds the `restart_override` flag to the top level of the config. This allows changing the schedule, callbacks, or device_train_microbatch_size from the checkpoint we are resuming model training from.
