### PR TITLE
Allow setting a new LR & WD on resumption

### DIFF
--- a/main.py
+++ b/main.py
@@ -452,7 +452,10 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
     if do_train:
         print("Starting training...")
         if cfg.get("restart_override", False):
-            print("Overriding checkpoint's scheduler and train microbatch size with config options")
+            print("Overriding checkpoint's scheduler, optimzier LR & WD, and train microbatch size with config options")
+            for param_group in trainer.state.optimizers[0].param_groups:
+                param_group["lr"] = cfg.optimizer.lr
+                param_group["weight_decay"] = cfg.optimizer.weight_decay
             trainer.fit(
                 schedulers=scheduler,
                 device_train_microbatch_size=cfg.get("device_train_microbatch_size", "auto"),


### PR DESCRIPTION
Since the optimizer state is loaded from the checkpoint on resumption, changing any optimize values needs to occur after the checkpoint is loaded but before `Trainer.fit` is called.

This also might be doable with a new callback which fires on the `after_load` event, assuming all the callbacks are not replaced from the checkpoint callbacks. But it looks like that [might happen per the docs](https://docs.mosaicml.com/projects/composer/en/stable/trainer/checkpointing.html#resume-training).
