### PR TITLE
Add reset_time configuration option

### DIFF
--- a/main.py
+++ b/main.py
@@ -465,9 +465,12 @@ def main(cfg: DictConfig, return_trainer: bool = False, do_train: bool = True) -
                     scheduler.base_lrs[i] = cfg.optimizer.lr
                 for i in range(len(scheduler._last_lr)):
                     scheduler._last_lr[i] = cfg.optimizer.lr
-            trainer.fit(device_train_microbatch_size=cfg.get("device_train_microbatch_size", "auto"))
+            trainer.fit(
+                device_train_microbatch_size=cfg.get("device_train_microbatch_size", "auto"),
+                reset_time=cfg.get("reset_time", False),
+            )
         else:
-            trainer.fit()
+            trainer.fit(reset_time=cfg.get("reset_time", False))
 
     if return_trainer:
         return trainer


### PR DESCRIPTION
This PR surfaces the `reset_time` argument as a top-level config setting for `Trainer.fit`. Reset time allows starting a new training run from existing weights and optimizer state with a new maximum duration. Doc string copied below:

> reset_time (bool): Whether to reset the :attr:`.State.timestamp` to zero values. Defaults to False.
> 
> If ``True``, the timestamp will be zeroed out, causing :class:`.ComposerScheduler` and
> :class:`.Algorithm` instances to start from the beginning, as if it is a new training run. The model
> will be trained for ``duration``, if specified, or for :attr:`.State.max_duration`, which would have
> been provided when constructing the :class:`.Trainer` or by a previous call to :meth:`.fit`.
> 
> .. note::
> 
> Model gradients, optimizer states, and native PyTorch schedulers will not be reset.
> 
> If ``False`` (the default), training time will be incremented from where the previous call to
> :meth:`.fit` finished (or from zero, if a new training run).
> The :attr:`~.State.max_duration` will be incremented by the ``duration`` parameter.